### PR TITLE
`Glyph.image = None` clears image

### DIFF
--- a/src/ufoLib2/objects/glyph.py
+++ b/src/ufoLib2/objects/glyph.py
@@ -100,7 +100,9 @@ class Glyph(object):
 
     @image.setter
     def image(self, image):
-        if isinstance(image, Image):
+        if image is None:
+            self._image.clear()
+        elif isinstance(image, Image):
             self._image = image
         else:
             self._image = Image(


### PR DESCRIPTION
This seems to be a defcon-ism: https://github.com/robotools/defcon/blob/master/Lib/defcon/objects/glyph.py#L1104. fontMath depends on it: https://github.com/robotools/fontMath/blob/master/Lib/fontMath/mathGlyph.py#L316 (`_compressImage` returns `None` if no `fileName` is set).