### PR TITLE
GlyphPointPen.addComponent: explicitly use identifier argument

### DIFF
--- a/src/ufoLib2/pointPens/glyphPointPen.py
+++ b/src/ufoLib2/pointPens/glyphPointPen.py
@@ -39,6 +39,8 @@ class GlyphPointPen(AbstractPointPen):
             )
         )
 
-    def addComponent(self, baseGlyph, transformation, **kwargs):
-        component = Component(baseGlyph, transformation, **kwargs)
+    def addComponent(
+        self, baseGlyph, transformation, identifier=None, **kwargs
+    ):
+        component = Component(baseGlyph, transformation, identifier=identifier)
         self._glyph.components.append(component)


### PR DESCRIPTION
fontMath's `FilterRedundantPointPen` does this: https://github.com/robotools/fontMath/blob/master/Lib/fontMath/mathGlyph.py#L486. The non-kwarg form of `identifier` in the functional call fails the call.

Not sure if this is a bug in fontMath? Any reason we want to have `**kwargs`?