### PR TITLE
Housekeeping

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,7 +11,7 @@ source = ufoLib2
 source =
     src/ufoLib2
     .tox/*/lib/python*/site-packages/ufoLib2
-    .tox/pypy*/site-packages/ufoLib2
+    .tox/*/lib/site-packages/ufoLib2
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,30 @@
 repos:
 - repo: https://github.com/ambv/black
-  rev: 19.3b0
+  rev: 19.10b0
   hooks:
   - id: black
-    language_version: python3
+    language: python_venv
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.2.3
+  rev: v2.4.0
   hooks:
   - id: trailing-whitespace
+    language: python_venv
   - id: end-of-file-fixer
+    language: python_venv
   - id: check-yaml
+    language: python_venv
   - id: check-ast
+    language: python_venv
   - id: mixed-line-ending
     args: ["--fix=lf"]
+    language: python_venv
   - id: debug-statements
+    language: python_venv
   - id: flake8
     additional_dependencies: [flake8-bugbear, flake8-mypy]
+    language: python_venv
 - repo: https://github.com/asottile/pyupgrade
-  rev: v1.17.1
+  rev: v1.25.1
   hooks:
   - id: pyupgrade
+    language: python_venv

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,6 +3,7 @@ mypy_path = src
 python_version = 3.6
 strict_optional = True
 warn_unreachable = True
+disallow_incomplete_defs = True
 
 [mypy-fontTools.*]
 ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools_scm>=1.15"]
+requires = ["setuptools>=30.3.0", "wheel", "setuptools_scm"]
 
 [tool.black]
 target-version = ["py36"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,10 @@ requires = ["setuptools>=30.3.0", "wheel", "setuptools_scm"]
 
 [tool.black]
 target-version = ["py36"]
+
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+line_length = 88

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,41 @@
+[metadata]
+name = ufoLib2
+description = ufoLib2 is a UFO font processing library.
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/fonttools/ufoLib2
+author = Adrien Tétar
+author_email = adri-from-59@hotmail.fr
+license = Apache 2.0
+license_file = LICENSE
+classifiers =
+    Development Status :: 4 - Beta
+    Operating System :: OS Independent
+    Programming Language :: Python :: 3
+    Intended Audience :: Developers
+    Intended Audience :: End Users/Desktop
+    Topic :: Text Processing :: Fonts
+    License :: OSI Approved :: Apache Software License
+
+[options]
+package_dir = =src
+packages = find:
+python_requires = >=3.6
+setup_requires =
+    setuptools_scm
+    wheel
+install_requires =
+    attrs >= 18.2.0
+    fonttools[ufo] >= 3.34.0
+
+[options.extras_require]
+lxml = lxml
+
+[options.packages.find]
+where = src
+
+[bdist_wheel]
+universal = 0
+
 [sdist]
 formats = zip
-
-[metadata]
-license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -1,35 +1,3 @@
-#!/usr/bin/env python
-from setuptools import setup, find_packages
+from setuptools import setup
 
-
-with open("README.md", "r", encoding="utf-8") as f:
-    long_description = f.read()
-
-setup(
-    name="ufoLib2",
-    use_scm_version={"write_to": "src/ufoLib2/_version.py"},
-    description="ufoLib2 is a UFO font library.",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    author="Adrien Tétar",
-    author_email="adri-from-59@hotmail.fr",
-    url="https://github.com/adrientetar/ufoLib2",
-    license="Apache 2.0",
-    package_dir={"": "src"},
-    packages=find_packages("src"),
-    include_package_data=True,
-    python_requires=">=3.6",
-    install_requires=["fonttools[ufo] >= 3.34.0", "attrs >= 18.2.0"],
-    setup_requires=["setuptools_scm"],
-    extras_require={"lxml": ["lxml"]},
-    classifiers=[
-        "Development Status :: 4 - Beta",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Intended Audience :: Developers",
-        "Intended Audience :: End Users/Desktop",
-        "Topic :: Text Processing :: Fonts",
-        "License :: OSI Approved :: Apache Software License",
-    ],
-)
+setup(use_scm_version={"write_to": "src/ufoLib2/_version.py"},)

--- a/src/ufoLib2/objects/__init__.py
+++ b/src/ufoLib2/objects/__init__.py
@@ -10,7 +10,6 @@ from ufoLib2.objects.layer import Layer
 from ufoLib2.objects.layerSet import LayerSet
 from ufoLib2.objects.point import Point
 
-
 __all__ = [
     "Anchor",
     "Component",

--- a/src/ufoLib2/objects/anchor.py
+++ b/src/ufoLib2/objects/anchor.py
@@ -1,5 +1,7 @@
-import attr
 from typing import Optional, Union
+
+import attr
+
 from ufoLib2.objects.misc import AttrDictMixin
 
 

--- a/src/ufoLib2/objects/component.py
+++ b/src/ufoLib2/objects/component.py
@@ -1,8 +1,9 @@
-import attr
+import warnings
 from typing import Optional
+
+import attr
 from fontTools.misc.transform import Identity, Transform
 from fontTools.pens.pointPen import PointToSegmentPen
-import warnings
 
 from .misc import _convert_transform
 

--- a/src/ufoLib2/objects/component.py
+++ b/src/ufoLib2/objects/component.py
@@ -4,9 +4,7 @@ from fontTools.misc.transform import Identity, Transform
 from fontTools.pens.pointPen import PointToSegmentPen
 import warnings
 
-
-def _convert_transform(t) -> Transform:
-    return t if isinstance(t, Transform) else Transform(*t)
+from .misc import _convert_transform
 
 
 @attr.s(slots=True)

--- a/src/ufoLib2/objects/component.py
+++ b/src/ufoLib2/objects/component.py
@@ -10,7 +10,7 @@ def _convert_transform(t) -> Transform:
 
 
 @attr.s(slots=True)
-class Component(object):
+class Component:
     baseGlyph = attr.ib(type=str)
     transformation = attr.ib(
         default=Identity, converter=_convert_transform, type=Transform

--- a/src/ufoLib2/objects/contour.py
+++ b/src/ufoLib2/objects/contour.py
@@ -1,9 +1,10 @@
+import warnings
 from collections.abc import MutableSequence
 from typing import Optional
-import warnings
 
 import attr
 from fontTools.pens.pointPen import PointToSegmentPen
+
 from ufoLib2.objects.point import Point
 
 

--- a/src/ufoLib2/objects/dataSet.py
+++ b/src/ufoLib2/objects/dataSet.py
@@ -1,6 +1,6 @@
+from fontTools.ufoLib import UFOReader, UFOWriter
+
 from ufoLib2.objects.misc import DataStore
-from fontTools.ufoLib import UFOReader
-from fontTools.ufoLib import UFOWriter
 
 
 class DataSet(DataStore):

--- a/src/ufoLib2/objects/features.py
+++ b/src/ufoLib2/objects/features.py
@@ -2,7 +2,7 @@ import attr
 
 
 @attr.s(slots=True)
-class Features(object):
+class Features:
     text = attr.ib(default="", type=str)
 
     def __bool__(self):

--- a/src/ufoLib2/objects/font.py
+++ b/src/ufoLib2/objects/font.py
@@ -1,16 +1,18 @@
-import attr
 import os
 import shutil
+from typing import Any, Mapping, Union
+
+import attr
 import fs.tempfs
+from fontTools.ufoLib import UFOFileStructure, UFOReader, UFOWriter
+
 from ufoLib2.constants import DEFAULT_LAYER_NAME
 from ufoLib2.objects.dataSet import DataSet
+from ufoLib2.objects.features import Features
 from ufoLib2.objects.guideline import Guideline
 from ufoLib2.objects.imageSet import ImageSet
 from ufoLib2.objects.info import Info
 from ufoLib2.objects.layerSet import LayerSet
-from ufoLib2.objects.features import Features
-from fontTools.ufoLib import UFOReader, UFOWriter, UFOFileStructure
-from typing import Union, Any, Mapping
 
 
 def _convert_Info(value: Union[Info, Mapping[str, Any]]) -> Info:

--- a/src/ufoLib2/objects/font.py
+++ b/src/ufoLib2/objects/font.py
@@ -10,21 +10,22 @@ from ufoLib2.objects.info import Info
 from ufoLib2.objects.layerSet import LayerSet
 from ufoLib2.objects.features import Features
 from fontTools.ufoLib import UFOReader, UFOWriter, UFOFileStructure
+from typing import Union, Any, Mapping
 
 
-def _convert_Info(value) -> Info:
+def _convert_Info(value: Union[Info, Mapping[str, Any]]) -> Info:
     return value if isinstance(value, Info) else Info(**value)
 
 
-def _convert_DataSet(value) -> DataSet:
+def _convert_DataSet(value: Union[DataSet, Mapping[str, Any]]) -> DataSet:
     return value if isinstance(value, DataSet) else DataSet(**value)
 
 
-def _convert_ImageSet(value) -> ImageSet:
+def _convert_ImageSet(value: Union[ImageSet, Mapping[str, Any]]) -> ImageSet:
     return value if isinstance(value, ImageSet) else ImageSet(**value)
 
 
-def _convert_Features(value) -> Features:
+def _convert_Features(value: Union[Features, str]) -> Features:
     return value if isinstance(value, Features) else Features(value)
 
 

--- a/src/ufoLib2/objects/font.py
+++ b/src/ufoLib2/objects/font.py
@@ -29,7 +29,7 @@ def _convert_Features(value) -> Features:
 
 
 @attr.s(slots=True, kw_only=True, repr=False)
-class Font(object):
+class Font:
     layers = attr.ib(
         default=attr.Factory(LayerSet),
         validator=attr.validators.instance_of(LayerSet),

--- a/src/ufoLib2/objects/glyph.py
+++ b/src/ufoLib2/objects/glyph.py
@@ -1,11 +1,13 @@
-import attr
 from copy import deepcopy
-from typing import Union, List, Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Union
+
+import attr
+from fontTools.misc.transform import Transform
+from fontTools.pens.pointPen import PointToSegmentPen, SegmentToPointPen
+
 from ufoLib2.objects.anchor import Anchor
 from ufoLib2.objects.guideline import Guideline
 from ufoLib2.objects.image import Image
-from fontTools.pens.pointPen import PointToSegmentPen, SegmentToPointPen
-from fontTools.misc.transform import Transform
 from ufoLib2.pointPens.glyphPointPen import GlyphPointPen
 
 

--- a/src/ufoLib2/objects/glyph.py
+++ b/src/ufoLib2/objects/glyph.py
@@ -10,7 +10,7 @@ from ufoLib2.pointPens.glyphPointPen import GlyphPointPen
 
 
 @attr.s(slots=True, repr=False)
-class Glyph(object):
+class Glyph:
     _name = attr.ib(type=str)
     width = attr.ib(default=0, type=Union[int, float])
     height = attr.ib(default=0, type=Union[int, float])

--- a/src/ufoLib2/objects/guideline.py
+++ b/src/ufoLib2/objects/guideline.py
@@ -1,5 +1,7 @@
-import attr
 from typing import Optional, Union
+
+import attr
+
 from ufoLib2.objects.misc import AttrDictMixin
 
 

--- a/src/ufoLib2/objects/image.py
+++ b/src/ufoLib2/objects/image.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import Optional, Sequence, Union
+from typing import Optional
 import attr
 from fontTools.misc.transform import Identity, Transform
 

--- a/src/ufoLib2/objects/image.py
+++ b/src/ufoLib2/objects/image.py
@@ -1,8 +1,8 @@
 from collections.abc import Mapping
 from typing import Optional
+
 import attr
 from fontTools.misc.transform import Identity, Transform
-
 
 from .misc import _convert_transform
 

--- a/src/ufoLib2/objects/image.py
+++ b/src/ufoLib2/objects/image.py
@@ -1,11 +1,10 @@
 from collections.abc import Mapping
-from typing import Optional
+from typing import Optional, Sequence, Union
 import attr
 from fontTools.misc.transform import Identity, Transform
 
 
-def _convert_transform(t) -> Transform:
-    return t if isinstance(t, Transform) else Transform(*t)
+from .misc import _convert_transform
 
 
 @attr.s(slots=True)

--- a/src/ufoLib2/objects/imageSet.py
+++ b/src/ufoLib2/objects/imageSet.py
@@ -1,6 +1,6 @@
+from fontTools.ufoLib import UFOReader, UFOWriter
+
 from ufoLib2.objects.misc import DataStore
-from fontTools.ufoLib import UFOReader
-from fontTools.ufoLib import UFOWriter
 
 
 class ImageSet(DataStore):

--- a/src/ufoLib2/objects/info.py
+++ b/src/ufoLib2/objects/info.py
@@ -1,9 +1,10 @@
-import attr
 from enum import IntEnum
-from typing import Optional, List, Union, Sequence, Any
-from ufoLib2.objects.misc import AttrDictMixin
-from ufoLib2.objects.guideline import Guideline
+from typing import Any, List, Optional, Sequence, Union
 
+import attr
+
+from ufoLib2.objects.guideline import Guideline
+from ufoLib2.objects.misc import AttrDictMixin
 
 __all__ = ["Info", "GaspRangeRecord", "NameRecord", "WidthClass"]
 

--- a/src/ufoLib2/objects/info.py
+++ b/src/ufoLib2/objects/info.py
@@ -1,6 +1,6 @@
 import attr
 from enum import IntEnum
-from typing import Optional, List, Union
+from typing import Optional, List, Union, Sequence, Any
 from ufoLib2.objects.misc import AttrDictMixin
 from ufoLib2.objects.guideline import Guideline
 
@@ -28,7 +28,9 @@ class GaspBehavior(IntEnum):
     SYMMETRIC_GRIDFIT = 3
 
 
-def _convert_GaspBehavior(seq) -> List[GaspBehavior]:
+def _convert_GaspBehavior(
+    seq: Sequence[Union[GaspBehavior, int]]
+) -> List[GaspBehavior]:
     return [v if isinstance(v, GaspBehavior) else GaspBehavior(v) for v in seq]
 
 
@@ -65,7 +67,7 @@ class WidthClass(IntEnum):
 
 def _convert_optional_list(lst, klass):
     if lst is None:
-        return
+        return None
     result = []
     for d in lst:
         if isinstance(d, klass):
@@ -75,20 +77,26 @@ def _convert_optional_list(lst, klass):
     return result
 
 
-def _convert_guidelines(values) -> Optional[List[Guideline]]:
+def _convert_guidelines(
+    values: Optional[Sequence[Union[Guideline, Any]]]
+) -> Optional[List[Guideline]]:
     return _convert_optional_list(values, Guideline)
 
 
-def _convert_gasp_range_records(values) -> Optional[List[GaspRangeRecord]]:
+def _convert_gasp_range_records(
+    values: Optional[Sequence[Union[GaspRangeRecord, Any]]]
+) -> Optional[List[GaspRangeRecord]]:
     return _convert_optional_list(values, GaspRangeRecord)
 
 
-def _convert_name_records(values) -> Optional[List[NameRecord]]:
+def _convert_name_records(
+    values: Optional[Sequence[Union[NameRecord, Any]]]
+) -> Optional[List[NameRecord]]:
     return _convert_optional_list(values, NameRecord)
 
 
-def _convert_WidthClass(value) -> Optional[WidthClass]:
-    return value if value is None else WidthClass(value)
+def _convert_WidthClass(value: Optional[int]) -> Optional[WidthClass]:
+    return None if value is None else WidthClass(value)
 
 
 @attr.s(slots=True)

--- a/src/ufoLib2/objects/info.py
+++ b/src/ufoLib2/objects/info.py
@@ -92,7 +92,7 @@ def _convert_WidthClass(value) -> Optional[WidthClass]:
 
 
 @attr.s(slots=True)
-class Info(object):
+class Info:
     familyName = attr.ib(default=None, type=Optional[str])
     styleName = attr.ib(default=None, type=Optional[str])
     styleMapFamilyName = attr.ib(default=None, type=Optional[str])

--- a/src/ufoLib2/objects/layer.py
+++ b/src/ufoLib2/objects/layer.py
@@ -17,7 +17,7 @@ def _convert_glyphs(value) -> Dict[str, Glyph]:
 
 
 @attr.s(slots=True, repr=False)
-class Layer(object):
+class Layer:
     _name = attr.ib(default=DEFAULT_LAYER_NAME, type=str)
     _glyphs = attr.ib(default=attr.Factory(dict), converter=_convert_glyphs, type=dict)
     color = attr.ib(default=None, type=Optional[str])

--- a/src/ufoLib2/objects/layer.py
+++ b/src/ufoLib2/objects/layer.py
@@ -1,11 +1,13 @@
 import attr
-from typing import Optional, Dict
+from typing import Optional, Dict, Sequence, Union
 from ufoLib2.objects.glyph import Glyph
 from ufoLib2.objects.misc import _NOT_LOADED
 from ufoLib2.constants import DEFAULT_LAYER_NAME
 
 
-def _convert_glyphs(value) -> Dict[str, Glyph]:
+def _convert_glyphs(
+    value: Union[Dict[str, Glyph], Sequence[Glyph]]
+) -> Dict[str, Glyph]:
     if isinstance(value, dict):
         return value
     result: Dict[str, Glyph] = {}

--- a/src/ufoLib2/objects/layer.py
+++ b/src/ufoLib2/objects/layer.py
@@ -1,8 +1,10 @@
+from typing import Dict, Optional, Sequence, Union
+
 import attr
-from typing import Optional, Dict, Sequence, Union
+
+from ufoLib2.constants import DEFAULT_LAYER_NAME
 from ufoLib2.objects.glyph import Glyph
 from ufoLib2.objects.misc import _NOT_LOADED
-from ufoLib2.constants import DEFAULT_LAYER_NAME
 
 
 def _convert_glyphs(

--- a/src/ufoLib2/objects/layerSet.py
+++ b/src/ufoLib2/objects/layerSet.py
@@ -1,9 +1,11 @@
-import attr
-from typing import Iterable
 from collections import OrderedDict
-from ufoLib2.objects.misc import _NOT_LOADED
-from ufoLib2.objects.layer import Layer
+from typing import Iterable
+
+import attr
+
 from ufoLib2.constants import DEFAULT_LAYER_NAME
+from ufoLib2.objects.layer import Layer
+from ufoLib2.objects.misc import _NOT_LOADED
 
 
 def _convert_layers(value: Iterable[Layer]) -> "OrderedDict[str, Layer]":

--- a/src/ufoLib2/objects/layerSet.py
+++ b/src/ufoLib2/objects/layerSet.py
@@ -22,7 +22,7 @@ def _convert_layers(value: Iterable[Layer]) -> "OrderedDict[str, Layer]":
 
 
 @attr.s(slots=True, repr=False)
-class LayerSet(object):
+class LayerSet:
     _layers = attr.ib(
         default=attr.Factory(OrderedDict), converter=_convert_layers, type=OrderedDict
     )

--- a/src/ufoLib2/objects/misc.py
+++ b/src/ufoLib2/objects/misc.py
@@ -1,8 +1,8 @@
 from collections.abc import Mapping, MutableMapping
 from typing import Sequence, Union
-from fontTools.misc.transform import Transform
-import attr
 
+import attr
+from fontTools.misc.transform import Transform
 
 # sentinel value to signal a "lazy" object hasn't been loaded yet
 _NOT_LOADED = object()

--- a/src/ufoLib2/objects/misc.py
+++ b/src/ufoLib2/objects/misc.py
@@ -1,4 +1,6 @@
 from collections.abc import Mapping, MutableMapping
+from typing import Sequence, Union
+from fontTools.misc.transform import Transform
 import attr
 
 
@@ -110,3 +112,9 @@ class AttrDictMixin(Mapping):
 
     def __len__(self):
         return sum(1 for _ in self)
+
+
+def _convert_transform(t: Union[Transform, Sequence[Union[int, float]]]) -> Transform:
+    """Return a passed-in Transform as is, otherwise convert a sequence of
+    numbers to a Transform if need be."""
+    return t if isinstance(t, Transform) else Transform(*t)

--- a/src/ufoLib2/objects/misc.py
+++ b/src/ufoLib2/objects/misc.py
@@ -95,8 +95,10 @@ class DataStore(MutableMapping):
 
 
 class AttrDictMixin(Mapping):
-    """ Read attribute values using mapping interface. For use with Anchors and
-    Guidelines classes, where client code expects them to behave as dict.
+    """Read attribute values using mapping interface.
+
+    For use with Anchors and Guidelines classes, where client code
+    expects them to behave as dict.
     """
 
     def __getitem__(self, key):

--- a/src/ufoLib2/objects/point.py
+++ b/src/ufoLib2/objects/point.py
@@ -3,7 +3,7 @@ from typing import Optional, Union
 
 
 @attr.s(slots=True)
-class Point(object):
+class Point:
     x = attr.ib(type=Union[int, float])
     y = attr.ib(type=Union[int, float])
     type = attr.ib(type=Optional[str])

--- a/src/ufoLib2/objects/point.py
+++ b/src/ufoLib2/objects/point.py
@@ -1,5 +1,6 @@
-import attr
 from typing import Optional, Union
+
+import attr
 
 
 @attr.s(slots=True)

--- a/src/ufoLib2/pointPens/glyphPointPen.py
+++ b/src/ufoLib2/pointPens/glyphPointPen.py
@@ -1,4 +1,5 @@
 from fontTools.pens.pointPen import AbstractPointPen
+
 from ufoLib2.objects.component import Component
 from ufoLib2.objects.contour import Contour
 from ufoLib2.objects.point import Point

--- a/tests/test_ufoLib2.py
+++ b/tests/test_ufoLib2.py
@@ -32,7 +32,7 @@ def test_lazy_data_loading_inplace_no_load(ufo_UbuTestData):
 
 def test_lazy_data_loading_inplace_load_some(ufo_UbuTestData):
     ufo = ufo_UbuTestData
-    some_data = "abc".encode("ascii")
+    some_data = b"abc"
     ufo.data["com.github.fonttools.ttx/T_S_I__0.ttx"] = some_data
     ufo.save()
     assert all(


### PR DESCRIPTION
- pre-commit: Update deps, use `language: python_venv` everywhere to make it work with my Windows installation. pre-commit uses virtualenv by default otherwise.
- Turned on mypy's `disallow_incomplete_defs` option to increase strictness. Fixed all marked incomplete definitions.
- Removed some `object` subclassing that isn't necessary anymore in Python 3. Not sure how this got missed by the pyupgrade pre-commit hook.
- Port setup.py to the declarative setup.cfg format because I can.
- Add a Windows-specific lib installation dir so coverage comes out correct on Windows.
- Sort imports.