### PR TITLE
make Glyph.name optional for compatibilty with defcon

### DIFF
--- a/src/ufoLib2/objects/glyph.py
+++ b/src/ufoLib2/objects/glyph.py
@@ -14,7 +14,7 @@ from ufoLib2.pointPens.glyphPointPen import GlyphPointPen
 
 @attr.s(slots=True, repr=False)
 class Glyph:
-    _name = attr.ib(type=str)
+    _name = attr.ib(default=None, type=Optional[str])
     width = attr.ib(default=0, type=Union[int, float])
     height = attr.ib(default=0, type=Union[int, float])
     unicodes = attr.ib(default=attr.Factory(list), type=List[int])
@@ -40,10 +40,10 @@ class Glyph:
         return iter(self.contours)
 
     def __repr__(self):
-        return "<{}.{} '{}' at {}>".format(
+        return "<{}.{} {}at {}>".format(
             self.__class__.__module__,
             self.__class__.__name__,
-            self._name,
+            f"'{self._name}' " if self._name is not None else "",
             hex(id(self)),
         )
 

--- a/src/ufoLib2/objects/layer.py
+++ b/src/ufoLib2/objects/layer.py
@@ -172,6 +172,10 @@ class Layer:
         # add it back
         self._glyphs[newName] = glyph
 
+    def instantiateGlyphObject(self):
+        # only for defcon API compatibility
+        return Glyph()
+
     def write(self, glyphSet, saveAs=True):
         glyphs = self._glyphs
         if not saveAs:

--- a/src/ufoLib2/objects/layer.py
+++ b/src/ufoLib2/objects/layer.py
@@ -90,7 +90,7 @@ class Layer:
 
     def __setitem__(self, name, glyph):
         if not isinstance(glyph, Glyph):
-            raise TypeError("Expected Glyph, found %s" % type(glyph).__name__)
+            raise TypeError(f"Expected Glyph, found {type(glyph).__name__}")
         glyph._name = name
         self._glyphs[name] = glyph
 
@@ -136,8 +136,17 @@ class Layer:
         return self._name
 
     def addGlyph(self, glyph):
-        if glyph.name in self._glyphs:
-            raise KeyError("glyph %r already exists" % glyph.name)
+        self.insertGlyph(glyph, overwrite=False, copy=False)
+
+    def insertGlyph(self, glyph, name=None, overwrite=True, copy=True):
+        if copy:
+            glyph = glyph.copy()
+        if name is not None:
+            glyph._name = name
+        if glyph.name is None:
+            raise ValueError(f"{glyph!r} has no name; can't add it to Layer")
+        if not overwrite and glyph.name in self._glyphs:
+            raise KeyError(f"glyph named '{glyph.name}' already exists")
         self._glyphs[glyph.name] = glyph
 
     def loadGlyph(self, name):
@@ -148,7 +157,7 @@ class Layer:
 
     def newGlyph(self, name):
         if name in self._glyphs:
-            raise KeyError("glyph %r already exists" % name)
+            raise KeyError(f"glyph named '{name}' already exists")
         self._glyphs[name] = glyph = Glyph(name)
         return glyph
 
@@ -156,7 +165,7 @@ class Layer:
         if name == newName:
             return
         if not overwrite and newName in self._glyphs:
-            raise KeyError("target glyph %r already exists" % newName)
+            raise KeyError(f"target glyph named '{newName}' already exists")
         # pop and set name
         glyph = self.pop(name)
         glyph._name = newName

--- a/tests/objects/test_glyph.py
+++ b/tests/objects/test_glyph.py
@@ -89,3 +89,15 @@ def test_appendContour(ufo_UbuTestData):
 
     with pytest.raises(TypeError, match="Expected Contour, found object"):
         A.appendContour(object())
+
+
+def test_glyph_without_name():
+    assert Glyph().name is None
+
+
+def test_glyph_repr():
+    g = Glyph()
+    assert repr(g) == f"<ufoLib2.objects.glyph.Glyph at {hex(id(g))}>"
+
+    g = Glyph("a")
+    assert repr(g) == f"<ufoLib2.objects.glyph.Glyph 'a' at {hex(id(g))}>"

--- a/tests/objects/test_layer.py
+++ b/tests/objects/test_layer.py
@@ -1,0 +1,126 @@
+from ufoLib2.objects import Layer, Glyph
+
+import pytest
+
+
+def test_init_layer_with_glyphs_dict():
+    a = Glyph()
+    b = Glyph()
+
+    layer = Layer("My Layer", {"a": a, "b": b})
+
+    assert layer.name == "My Layer"
+    assert "a" in layer
+    assert layer["a"] is a
+    assert a.name == "a"
+    assert "b" in layer
+    assert layer["b"] is b
+    assert b.name == "b"
+
+    with pytest.raises(
+        ValueError, match="glyph has incorrect name: expected 'a', found 'b'"
+    ):
+        Layer(glyphs={"a": b})
+
+    with pytest.raises(KeyError, match=".*Glyph .* can't be added twice"):
+        Layer(glyphs={"a": a, "b": a})
+
+    with pytest.raises(TypeError, match="Expected Glyph, found int"):
+        Layer(glyphs={"a": 1})
+
+
+def test_init_layer_with_glyphs_list():
+    a = Glyph("a")
+    b = Glyph("b")
+    layer = Layer(glyphs=[a, b])
+
+    assert layer["a"] is a
+    assert layer["b"] is b
+
+    with pytest.raises(KeyError, match=".*Glyph .* can't be added twice"):
+        Layer(glyphs=[a, a])
+
+    c = Glyph()
+    with pytest.raises(ValueError, match=".*Glyph .* has no name"):
+        Layer(glyphs=[c])
+
+    with pytest.raises(KeyError, match="glyph named 'b' already exists"):
+        Layer(glyphs=[a, b, Glyph("b")])
+
+    with pytest.raises(TypeError, match="Expected Glyph, found int"):
+        Layer(glyphs=[1])
+
+
+def test_addGlyph():
+    a = Glyph("a")
+
+    layer = Layer()
+
+    layer.addGlyph(a)
+
+    assert "a" in layer
+    assert layer["a"] is a
+
+    with pytest.raises(KeyError, match="glyph named 'a' already exists"):
+        layer.addGlyph(a)
+
+
+def test_insertGlyph():
+    g = Glyph()
+    pen = g.getPen()
+    pen.moveTo((0, 0))
+    pen.lineTo((1, 1))
+    pen.lineTo((0, 1))
+    pen.closePath()
+
+    layer = Layer()
+    layer.insertGlyph(g, "a")
+
+    assert "a" in layer
+    assert layer["a"].name == "a"
+    assert layer["a"].contours == g.contours
+    assert layer["a"] is not g
+
+    layer.insertGlyph(g, "b")
+    assert "b" in layer
+    assert layer["b"].name == "b"
+    assert layer["b"].contours == layer["a"].contours
+    assert layer["b"] is not layer["a"]
+    assert layer["b"] is not g
+
+    assert g.name is None
+
+    with pytest.raises(KeyError, match="glyph named 'a' already exists"):
+        layer.insertGlyph(g, "a", overwrite=False)
+
+    with pytest.raises(ValueError, match=".*Glyph .* has no name; can't add it"):
+        layer.insertGlyph(g)
+
+
+def test_newGlyph():
+    layer = Layer()
+    a = layer.newGlyph("a")
+
+    assert "a" in layer
+    assert layer["a"] is a
+
+    with pytest.raises(KeyError, match="glyph named 'a' already exists"):
+        layer.newGlyph("a")
+
+
+def test_renameGlyph():
+    g = Glyph()
+
+    layer = Layer(glyphs={"a": g})
+    assert g.name == "a"
+
+    layer.renameGlyph("a", "a")  # no-op
+    assert g.name == "a"
+
+    layer.renameGlyph("a", "b")
+    assert g.name == "b"
+
+    layer.insertGlyph(g, "a")
+
+    with pytest.raises(KeyError, match="target glyph named 'a' already exists"):
+        layer.renameGlyph("b", "a")


### PR DESCRIPTION
as @typemytype wrote in https://github.com/googlefonts/ufo2ft/issues/363#issuecomment-588356886

> Its maybe not a good plan to make the api between the ufoLib2 and defcon so different. According the spec a glyph name is not required, so on init of a glyph object the name should not be a requirement. But ufoLib2 makes it a required argument, I think this is wrong... and makes packages like ufo2ft complex where it should not be...

this PR makes Glyph.name default to None (e.g. for Glyphs without a parent layer).
As soon as a name-less glyph is added to a Layer object, it gets a name defined by its key in the layer underlying dict.