### PR TITLE
Refactor DataStore and (Image|Data)Set

### DIFF
--- a/src/ufoLib2/objects/dataSet.py
+++ b/src/ufoLib2/objects/dataSet.py
@@ -1,10 +1,45 @@
+from typing import List
+
 from fontTools.ufoLib import UFOReader, UFOWriter
 
 from ufoLib2.objects.misc import DataStore
 
 
 class DataSet(DataStore):
-    listdir = UFOReader.getDataDirectoryListing
-    readf = UFOReader.readData
-    writef = UFOWriter.writeData
-    deletef = UFOWriter.removeData
+    """Represents a mapping of POSIX filename strings to arbitrary data bytes.
+
+    Always use forward slahes (/) as directory separators, even on Windows.
+
+    Behavior:
+        DataSet behaves like a dictionary of type ``Dict[str, bytes]``.
+
+        >>> from ufoLib2 import Font
+        >>> font = Font()
+        >>> font.data["test.txt"] = b"123"
+        >>> font.data["directory/my_binary_blob.bin"] = b"456"
+        >>> font.data["test.txt"]
+        b'123'
+        >>> del font.data["test.txt"]
+        >>> list(font.data.items())
+        [('directory/my_binary_blob.bin', b'456')]
+    """
+
+    @staticmethod
+    def list_contents(reader: UFOReader) -> List[str]:
+        """Returns a list of POSIX filename strings in the data store."""
+        return reader.getDataDirectoryListing()
+
+    @staticmethod
+    def read_data(reader: UFOReader, filename: str) -> bytes:
+        """Returns the data at filename within the store."""
+        return reader.readData(filename)
+
+    @staticmethod
+    def write_data(writer: UFOWriter, filename: str, data: bytes) -> None:
+        """Writes the data to filename within the store."""
+        writer.writeData(filename, data)
+
+    @staticmethod
+    def remove_data(writer: UFOWriter, filename: str) -> None:
+        """Remove the data at filename within the store."""
+        writer.removeData(filename)

--- a/src/ufoLib2/objects/imageSet.py
+++ b/src/ufoLib2/objects/imageSet.py
@@ -1,10 +1,54 @@
+from typing import List
+
 from fontTools.ufoLib import UFOReader, UFOWriter
 
 from ufoLib2.objects.misc import DataStore
 
 
 class ImageSet(DataStore):
-    listdir = UFOReader.getImageDirectoryListing
-    readf = UFOReader.readImage
-    writef = UFOWriter.writeImage
-    deletef = UFOWriter.removeImage
+    """Represents a mapping of POSIX filename strings to arbitrary image data.
+
+    Note:
+        Images cannot be put into subdirectories of the images folder.
+
+    Behavior:
+        ImageSet behaves like a dictionary of type ``Dict[str, bytes]``.
+
+        >>> from ufoLib2 import Font
+        >>> font = Font()
+        >>> # Note: invalid PNG data for demonstration. Use the actual PNG bytes.
+        >>> font.images["test.png"] = b"123"
+        >>> font.images["test2.png"] = b"456"
+        >>> font.images["test.png"]
+        b'123'
+        >>> del font.images["test.png"]
+        >>> list(font.images.items())
+        [('test2.png', b'456')]
+    """
+
+    @staticmethod
+    def list_contents(reader: UFOReader) -> List[str]:
+        """Returns a list of POSIX filename strings in the image data store."""
+        return reader.getImageDirectoryListing()
+
+    @staticmethod
+    def read_data(reader: UFOReader, filename: str) -> bytes:
+        """Returns the image data at filename within the store."""
+        return reader.readImage(filename)
+
+    @staticmethod
+    def write_data(writer: UFOWriter, filename: str, data: bytes) -> None:
+        """Writes the image data to filename within the store."""
+        writer.writeImage(filename, data)
+
+    @staticmethod
+    def remove_data(writer: UFOWriter, filename: str) -> None:
+        """Remove the image data at filename within the store."""
+        writer.removeImage(filename)
+
+    def __setitem__(self, fileName, data):
+        if "/" in fileName:
+            raise ValueError(
+                "Images cannot be put into subdirectories of the images folder."
+            )
+        super().__setitem__(fileName, data)

--- a/tests/objects/test_datastore.py
+++ b/tests/objects/test_datastore.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+import pytest
+
+from ufoLib2 import Font
+
+
+def test_imageset(tmp_path: Path) -> None:
+    font = Font()
+    font.images["test.png"] = b"\x89PNG\r\n\x1a\n123"
+    font.images["test2.png"] = b"\x89PNG\r\n\x1a\n456"
+    font_path = tmp_path / "a.ufo"
+    font.save(font_path)
+
+    font = Font.open(font_path)
+    assert font.images["test.png"] == b"\x89PNG\r\n\x1a\n123"
+    assert font.images["test2.png"] == b"\x89PNG\r\n\x1a\n456"
+
+    with pytest.raises(ValueError, match=r".*subdirectories.*"):
+        font.images["directory/test2.png"] = b"\x89PNG\r\n\x1a\n456"
+    with pytest.raises(KeyError):
+        font.images["directory/test2.png"]
+
+
+def test_dataset(tmp_path: Path) -> None:
+    font = Font()
+    font.data["test.png"] = b"123"
+    font.data["directory/test2.png"] = b"456"
+    font_path = tmp_path / "a.ufo"
+    font.save(font_path)
+
+    font = Font.open(font_path)
+    assert font.data["test.png"] == b"123"
+    assert font.data["directory/test2.png"] == b"456"


### PR DESCRIPTION
1. Use abstract methods for reading and writing contents.
2. Images can't be put into subdirectories.