### PR TITLE
CI: Break up build steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: '3.8'
+        python-version: '3.x'
     - name: Lint
       run: |
         pip install tox
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: '3.8'
+        python-version: '3.x'
     - name: Lint
       run: |
         pip install tox
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.9]
         platform: [ubuntu-latest, windows-latest]
 
     steps:
@@ -48,10 +48,12 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Test with tox
+    - name: Install packages
+      run: pip install tox coverage
+    - name: Run Tox
+      run: tox -e py-cov
+    - name: Produce coverage files
       run: |
-        pip install tox -r requirements-dev.txt
-        tox -e py-cov
         coverage combine
         coverage xml
     - name: Upload coverage to Codecov


### PR DESCRIPTION
Cramming everything into one step ignores tox failures?!

Also, test with minimum supported Python version and latest