### PR TITLE
Add public.objectLibs handling

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,6 +32,7 @@ master_doc = "index"
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,6 @@ target-version = ["py36"]
 
 [tool.isort]
 multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-line_length = 88
+profile = "black"
+float_to_top = true
 known_first_party = "ufoLib2"

--- a/src/ufoLib2/constants.py
+++ b/src/ufoLib2/constants.py
@@ -1,2 +1,11 @@
 DEFAULT_LAYER_NAME: str = "public.default"
 """The name of the default layer."""
+
+OBJECT_LIBS_KEY: str = "public.objectLibs"
+"""The lib key for object libs.
+
+See:
+
+- https://unifiedfontobject.org/versions/ufo3/lib.plist/#publicobjectlibs
+- https://unifiedfontobject.org/versions/ufo3/glyphs/glif/#publicobjectlibs
+"""

--- a/src/ufoLib2/objects/glyph.py
+++ b/src/ufoLib2/objects/glyph.py
@@ -25,8 +25,9 @@ from ufoLib2.objects.component import Component
 from ufoLib2.objects.contour import Contour
 from ufoLib2.objects.guideline import Guideline
 from ufoLib2.objects.image import Image
-from ufoLib2.objects.misc import BoundingBox, getBounds, getControlBounds
+from ufoLib2.objects.misc import BoundingBox, _object_lib, getBounds, getControlBounds
 from ufoLib2.pointPens.glyphPointPen import GlyphPointPen
+from ufoLib2.typing import HasIdentifier
 
 if TYPE_CHECKING:
     from ufoLib2.objects.layer import Layer  # noqa: F401
@@ -215,6 +216,28 @@ class Glyph:
                 ),
                 color=image.get("color"),
             )
+
+    def object_lib(self, object: HasIdentifier) -> Dict[str, Any]:
+        """Return the lib for an object with an identifier, as stored in a glyph's lib.
+
+        If the object does not yet have an identifier, a new one is assigned to it. If
+        the font lib does not yet contain the object's lib, a new one is inserted and
+        returned.
+
+        .. doctest::
+
+            >>> from ufoLib2.objects import Font, Guideline
+            >>> font = Font()
+            >>> glyph = font.newGlyph("a")
+            >>> glyph.guidelines = [Guideline(x=100)]
+            >>> guideline_lib = glyph.object_lib(glyph.guidelines[0])
+            >>> guideline_lib["com.test.foo"] = 1234
+            >>> guideline_id = glyph.guidelines[0].identifier
+            >>> assert guideline_id is not None
+            >>> assert glyph.lib["public.objectLibs"][guideline_id] is guideline_lib
+        """
+
+        return _object_lib(self.lib, object)
 
     def clear(self) -> None:
         """Clears out anchors, components, contours, guidelines and image

--- a/src/ufoLib2/typing.py
+++ b/src/ufoLib2/typing.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from typing import TypeVar, Union
+from typing import Optional, TypeVar, Union
 
 from fontTools.pens.basePen import AbstractPen
 
@@ -25,3 +25,10 @@ class Drawable(Protocol):
 
     def draw(self, pen: AbstractPen) -> None:
         ...
+
+
+class HasIdentifier(Protocol):
+    """Any object that has a unique identifier in some context that can be
+    used as a key in a public.objectLibs dictionary."""
+
+    identifier: Optional[str]

--- a/tests/objects/test_object_lib.py
+++ b/tests/objects/test_object_lib.py
@@ -1,0 +1,93 @@
+from ufoLib2.objects import Anchor, Font, Guideline
+
+
+def test_object_lib_roundtrip(tmp_path):
+    ufo = Font()
+
+    ufo.info.guidelines = [Guideline(x=100), Guideline(y=200)]
+    guideline_lib = ufo.object_lib(ufo.info.guidelines[1])
+    guideline_lib["com.test.foo"] = 1234
+
+    ufo.newGlyph("component")
+    glyph = ufo.newGlyph("test")
+
+    glyph.guidelines = [Guideline(x=300), Guideline(y=400)]
+    glyph_guideline_lib = glyph.object_lib(glyph.guidelines[1])
+    glyph_guideline_lib["com.test.foo"] = 4321
+
+    glyph.anchors = [Anchor(x=1, y=2, name="top"), Anchor(x=3, y=4, name="bottom")]
+    anchor_lib = glyph.object_lib(glyph.anchors[1])
+    anchor_lib["com.test.anchorTool"] = True
+
+    pen = glyph.getPen()
+    pen.moveTo((0, 0))
+    pen.lineTo((100, 200))
+    pen.lineTo((200, 400))
+    pen.closePath()
+    pen.moveTo((1000, 1000))
+    pen.lineTo((1000, 2000))
+    pen.lineTo((2000, 4000))
+    pen.closePath()
+    pen.addComponent("component", (1, 0, 0, 1, 0, 0))
+    pen.addComponent("component", (1, 0, 0, 1, 0, 0))
+
+    contour_lib = glyph.object_lib(glyph.contours[0])
+    contour_lib["com.test.foo"] = "abc"
+    point_lib = glyph.object_lib(glyph.contours[1].points[0])
+    point_lib["com.test.foo"] = "abc"
+    component_lib = glyph.object_lib(glyph.components[0])
+    component_lib["com.test.foo"] = "abc"
+
+    ufo.save(tmp_path / "test.ufo")
+
+    # Roundtrip
+    ufo_reload = Font.open(tmp_path / "test.ufo")
+
+    reload_guideline_lib = ufo_reload.object_lib(ufo_reload.info.guidelines[1])
+    reload_glyph = ufo_reload["test"]
+    reload_glyph_guideline_lib = reload_glyph.object_lib(reload_glyph.guidelines[1])
+    reload_anchor_lib = reload_glyph.object_lib(reload_glyph.anchors[1])
+    reload_contour_lib = reload_glyph.object_lib(reload_glyph.contours[0])
+    reload_point_lib = reload_glyph.object_lib(reload_glyph.contours[1].points[0])
+    reload_component_lib = reload_glyph.object_lib(reload_glyph.components[0])
+
+    assert reload_guideline_lib == guideline_lib
+    assert reload_glyph_guideline_lib == glyph_guideline_lib
+    assert reload_anchor_lib == anchor_lib
+    assert reload_contour_lib == contour_lib
+    assert reload_point_lib == point_lib
+    assert reload_component_lib == component_lib
+
+
+def test_object_lib_prune(tmp_path):
+    ufo = Font()
+
+    ufo.info.guidelines = [Guideline(x=100), Guideline(y=200)]
+    _ = ufo.object_lib(ufo.info.guidelines[0])
+    guideline_lib = ufo.object_lib(ufo.info.guidelines[1])
+    guideline_lib["com.test.foo"] = 1234
+    ufo.lib["public.objectLibs"]["aaaa"] = {"1": 1}
+
+    ufo.newGlyph("component")
+    glyph = ufo.newGlyph("test")
+
+    glyph.guidelines = [Guideline(x=300), Guideline(y=400)]
+    _ = glyph.object_lib(glyph.guidelines[0])
+    glyph_guideline_lib = glyph.object_lib(glyph.guidelines[1])
+    glyph_guideline_lib["com.test.foo"] = 4321
+    glyph.lib["public.objectLibs"]["aaaa"] = {"1": 1}
+
+    ufo.save(tmp_path / "test.ufo")
+
+    # Roundtrip
+    ufo_reload = Font.open(tmp_path / "test.ufo")
+    assert set(ufo_reload.lib["public.objectLibs"].keys()) == {
+        ufo.info.guidelines[1].identifier
+    }
+    assert set(ufo_reload["test"].lib["public.objectLibs"].keys()) == {
+        glyph.guidelines[1].identifier
+    }
+
+    # Empty object libs are pruned from objectLibs, but the identifiers stay.
+    assert ufo.info.guidelines[0].identifier is not None
+    assert glyph.guidelines[0].identifier is not None

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     -r requirements-dev.txt
 commands =
     black --check --diff .
-    isort --check-only --diff --recursive src tests
+    isort --check-only --diff src tests
     mypy src tests .
     flake8
 


### PR DESCRIPTION
The current iteration of this PR adds `object_lib(obj)` methods to `Font` and `Glyph`, where `obj` is the object you want to get the lib of (anchor, guideline, ...). If the object does not have an identifier yet, it gets assigned one.

This is simpler than changing the objects to carry their own lib, but also means that the lib of an object is not free-floating but really tied to the containing `Font` or `Glyph` object. This reflects how the data is serialized. UFO v4 may change this, we then change the API.