### PR TITLE
Rename object_lib to objectLib

### DIFF
--- a/src/ufoLib2/objects/font.py
+++ b/src/ufoLib2/objects/font.py
@@ -371,7 +371,7 @@ class Font:
         for guideline in value:
             self.appendGuideline(guideline)
 
-    def object_lib(self, object: HasIdentifier) -> Dict[str, Any]:
+    def objectLib(self, object: HasIdentifier) -> Dict[str, Any]:
         """Return the lib for an object with an identifier, as stored in a font's lib.
 
         If the object does not yet have an identifier, a new one is assigned to it. If
@@ -383,7 +383,7 @@ class Font:
             >>> from ufoLib2.objects import Font, Guideline
             >>> font = Font()
             >>> font.guidelines = [Guideline(x=100)]
-            >>> guideline_lib = font.object_lib(font.guidelines[0])
+            >>> guideline_lib = font.objectLib(font.guidelines[0])
             >>> guideline_lib["com.test.foo"] = 1234
             >>> guideline_id = font.guidelines[0].identifier
             >>> assert guideline_id is not None

--- a/src/ufoLib2/objects/glyph.py
+++ b/src/ufoLib2/objects/glyph.py
@@ -217,7 +217,7 @@ class Glyph:
                 color=image.get("color"),
             )
 
-    def object_lib(self, object: HasIdentifier) -> Dict[str, Any]:
+    def objectLib(self, object: HasIdentifier) -> Dict[str, Any]:
         """Return the lib for an object with an identifier, as stored in a glyph's lib.
 
         If the object does not yet have an identifier, a new one is assigned to it. If
@@ -230,7 +230,7 @@ class Glyph:
             >>> font = Font()
             >>> glyph = font.newGlyph("a")
             >>> glyph.guidelines = [Guideline(x=100)]
-            >>> guideline_lib = glyph.object_lib(glyph.guidelines[0])
+            >>> guideline_lib = glyph.objectLib(glyph.guidelines[0])
             >>> guideline_lib["com.test.foo"] = 1234
             >>> guideline_id = glyph.guidelines[0].identifier
             >>> assert guideline_id is not None

--- a/tests/objects/test_object_lib.py
+++ b/tests/objects/test_object_lib.py
@@ -5,18 +5,18 @@ def test_object_lib_roundtrip(tmp_path):
     ufo = Font()
 
     ufo.info.guidelines = [Guideline(x=100), Guideline(y=200)]
-    guideline_lib = ufo.object_lib(ufo.info.guidelines[1])
+    guideline_lib = ufo.objectLib(ufo.info.guidelines[1])
     guideline_lib["com.test.foo"] = 1234
 
     ufo.newGlyph("component")
     glyph = ufo.newGlyph("test")
 
     glyph.guidelines = [Guideline(x=300), Guideline(y=400)]
-    glyph_guideline_lib = glyph.object_lib(glyph.guidelines[1])
+    glyph_guideline_lib = glyph.objectLib(glyph.guidelines[1])
     glyph_guideline_lib["com.test.foo"] = 4321
 
     glyph.anchors = [Anchor(x=1, y=2, name="top"), Anchor(x=3, y=4, name="bottom")]
-    anchor_lib = glyph.object_lib(glyph.anchors[1])
+    anchor_lib = glyph.objectLib(glyph.anchors[1])
     anchor_lib["com.test.anchorTool"] = True
 
     pen = glyph.getPen()
@@ -31,11 +31,11 @@ def test_object_lib_roundtrip(tmp_path):
     pen.addComponent("component", (1, 0, 0, 1, 0, 0))
     pen.addComponent("component", (1, 0, 0, 1, 0, 0))
 
-    contour_lib = glyph.object_lib(glyph.contours[0])
+    contour_lib = glyph.objectLib(glyph.contours[0])
     contour_lib["com.test.foo"] = "abc"
-    point_lib = glyph.object_lib(glyph.contours[1].points[0])
+    point_lib = glyph.objectLib(glyph.contours[1].points[0])
     point_lib["com.test.foo"] = "abc"
-    component_lib = glyph.object_lib(glyph.components[0])
+    component_lib = glyph.objectLib(glyph.components[0])
     component_lib["com.test.foo"] = "abc"
 
     ufo.save(tmp_path / "test.ufo")
@@ -43,13 +43,13 @@ def test_object_lib_roundtrip(tmp_path):
     # Roundtrip
     ufo_reload = Font.open(tmp_path / "test.ufo")
 
-    reload_guideline_lib = ufo_reload.object_lib(ufo_reload.info.guidelines[1])
+    reload_guideline_lib = ufo_reload.objectLib(ufo_reload.info.guidelines[1])
     reload_glyph = ufo_reload["test"]
-    reload_glyph_guideline_lib = reload_glyph.object_lib(reload_glyph.guidelines[1])
-    reload_anchor_lib = reload_glyph.object_lib(reload_glyph.anchors[1])
-    reload_contour_lib = reload_glyph.object_lib(reload_glyph.contours[0])
-    reload_point_lib = reload_glyph.object_lib(reload_glyph.contours[1].points[0])
-    reload_component_lib = reload_glyph.object_lib(reload_glyph.components[0])
+    reload_glyph_guideline_lib = reload_glyph.objectLib(reload_glyph.guidelines[1])
+    reload_anchor_lib = reload_glyph.objectLib(reload_glyph.anchors[1])
+    reload_contour_lib = reload_glyph.objectLib(reload_glyph.contours[0])
+    reload_point_lib = reload_glyph.objectLib(reload_glyph.contours[1].points[0])
+    reload_component_lib = reload_glyph.objectLib(reload_glyph.components[0])
 
     assert reload_guideline_lib == guideline_lib
     assert reload_glyph_guideline_lib == glyph_guideline_lib
@@ -63,8 +63,8 @@ def test_object_lib_prune(tmp_path):
     ufo = Font()
 
     ufo.info.guidelines = [Guideline(x=100), Guideline(y=200)]
-    _ = ufo.object_lib(ufo.info.guidelines[0])
-    guideline_lib = ufo.object_lib(ufo.info.guidelines[1])
+    _ = ufo.objectLib(ufo.info.guidelines[0])
+    guideline_lib = ufo.objectLib(ufo.info.guidelines[1])
     guideline_lib["com.test.foo"] = 1234
     ufo.lib["public.objectLibs"]["aaaa"] = {"1": 1}
 
@@ -72,8 +72,8 @@ def test_object_lib_prune(tmp_path):
     glyph = ufo.newGlyph("test")
 
     glyph.guidelines = [Guideline(x=300), Guideline(y=400)]
-    _ = glyph.object_lib(glyph.guidelines[0])
-    glyph_guideline_lib = glyph.object_lib(glyph.guidelines[1])
+    _ = glyph.objectLib(glyph.guidelines[0])
+    glyph_guideline_lib = glyph.objectLib(glyph.guidelines[1])
     glyph_guideline_lib["com.test.foo"] = 4321
     glyph.lib["public.objectLibs"]["aaaa"] = {"1": 1}
 


### PR DESCRIPTION
CamelCase is the prevailing casing sadly. Missed this the first time around.