### PR TITLE
Add GlyphSet protocol

### DIFF
--- a/src/ufoLib2/objects/component.py
+++ b/src/ufoLib2/objects/component.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import Optional, Tuple
 
 import attr
 from fontTools.misc.transform import Identity, Transform
@@ -7,11 +7,9 @@ from fontTools.pens.basePen import AbstractPen
 from fontTools.pens.pointPen import AbstractPointPen, PointToSegmentPen
 
 from ufoLib2.objects.misc import BoundingBox
+from ufoLib2.typing import GlyphSet
 
 from .misc import _convert_transform, getBounds, getControlBounds
-
-if TYPE_CHECKING:
-    from ufoLib2.objects.layer import Layer
 
 
 @attr.s(auto_attribs=True, slots=True)
@@ -39,7 +37,7 @@ class Component:
         x, y = delta
         self.transformation = self.transformation.translate(x, y)
 
-    def getBounds(self, layer: "Layer") -> Optional[BoundingBox]:
+    def getBounds(self, layer: GlyphSet) -> Optional[BoundingBox]:
         """Returns the (xMin, yMin, xMax, yMax) bounding box of the component,
         taking the actual contours into account.
 
@@ -48,7 +46,7 @@ class Component:
         """
         return getBounds(self, layer)
 
-    def getControlBounds(self, layer: "Layer") -> Optional[BoundingBox]:
+    def getControlBounds(self, layer: GlyphSet) -> Optional[BoundingBox]:
         """Returns the (xMin, yMin, xMax, yMax) bounding box of the component,
         taking only the control points into account.
 

--- a/src/ufoLib2/objects/contour.py
+++ b/src/ufoLib2/objects/contour.py
@@ -1,15 +1,6 @@
 import warnings
 from collections.abc import MutableSequence
-from typing import (
-    TYPE_CHECKING,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Tuple,
-    Union,
-    overload,
-)
+from typing import Iterable, Iterator, List, Optional, Tuple, Union, overload
 
 import attr
 from fontTools.pens.basePen import AbstractPen
@@ -17,9 +8,7 @@ from fontTools.pens.pointPen import AbstractPointPen, PointToSegmentPen
 
 from ufoLib2.objects.misc import BoundingBox, getBounds, getControlBounds
 from ufoLib2.objects.point import Point
-
-if TYPE_CHECKING:
-    from ufoLib2.objects.layer import Layer  # noqa: F401
+from ufoLib2.typing import GlyphSet
 
 
 @attr.s(auto_attribs=True, slots=True)
@@ -116,7 +105,7 @@ class Contour(MutableSequence):
         for point in self.points:
             point.move(delta)
 
-    def getBounds(self, layer: Optional["Layer"] = None) -> Optional[BoundingBox]:
+    def getBounds(self, layer: Optional[GlyphSet] = None) -> Optional[BoundingBox]:
         """Returns the (xMin, yMin, xMax, yMax) bounding box of the glyph,
         taking the actual contours into account.
 
@@ -135,7 +124,7 @@ class Contour(MutableSequence):
         return self.getBounds()
 
     def getControlBounds(
-        self, layer: Optional["Layer"] = None
+        self, layer: Optional[GlyphSet] = None
     ) -> Optional[BoundingBox]:
         """Returns the (xMin, yMin, xMax, yMax) bounding box of the glyph,
         taking only the control points into account.

--- a/src/ufoLib2/objects/font.py
+++ b/src/ufoLib2/objects/font.py
@@ -221,7 +221,7 @@ class Font:
             self._reader = reader
         return self
 
-    def __contains__(self, name: str) -> bool:
+    def __contains__(self, name: object) -> bool:
         return name in self.layers.defaultLayer
 
     def __delitem__(self, name: str) -> None:

--- a/src/ufoLib2/objects/glyph.py
+++ b/src/ufoLib2/objects/glyph.py
@@ -1,15 +1,5 @@
 from copy import deepcopy
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Iterator,
-    List,
-    Mapping,
-    Optional,
-    Tuple,
-    Union,
-)
+from typing import Any, Dict, Iterator, List, Mapping, Optional, Tuple, Union
 
 import attr
 from fontTools.misc.transform import Transform
@@ -27,10 +17,7 @@ from ufoLib2.objects.guideline import Guideline
 from ufoLib2.objects.image import Image
 from ufoLib2.objects.misc import BoundingBox, _object_lib, getBounds, getControlBounds
 from ufoLib2.pointPens.glyphPointPen import GlyphPointPen
-from ufoLib2.typing import HasIdentifier
-
-if TYPE_CHECKING:
-    from ufoLib2.objects.layer import Layer  # noqa: F401
+from ufoLib2.typing import GlyphSet, HasIdentifier
 
 
 @attr.s(auto_attribs=True, slots=True, repr=False)
@@ -420,7 +407,7 @@ class Glyph:
 
     # bounds and side-bearings
 
-    def getBounds(self, layer: Optional["Layer"] = None) -> Optional[BoundingBox]:
+    def getBounds(self, layer: Optional[GlyphSet] = None) -> Optional[BoundingBox]:
         """Returns the (xMin, yMin, xMax, yMax) bounding box of the glyph,
         taking the actual contours into account.
 
@@ -434,7 +421,7 @@ class Glyph:
         return getBounds(self, layer)
 
     def getControlBounds(
-        self, layer: Optional["Layer"] = None
+        self, layer: Optional[GlyphSet] = None
     ) -> Optional[BoundingBox]:
         """Returns the (xMin, yMin, xMax, yMax) bounding box of the glyph,
         taking only the control points into account.
@@ -448,7 +435,7 @@ class Glyph:
 
         return getControlBounds(self, layer)
 
-    def getLeftMargin(self, layer: Optional["Layer"] = None) -> Optional[float]:
+    def getLeftMargin(self, layer: Optional[GlyphSet] = None) -> Optional[float]:
         """Returns the the space in font units from the point of origin to the
         left side of the glyph.
 
@@ -461,7 +448,7 @@ class Glyph:
             return None
         return bounds.xMin
 
-    def setLeftMargin(self, value: float, layer: Optional["Layer"] = None) -> None:
+    def setLeftMargin(self, value: float, layer: Optional[GlyphSet] = None) -> None:
         """Sets the the space in font units from the point of origin to the
         left side of the glyph.
 
@@ -478,7 +465,7 @@ class Glyph:
             self.width += diff
             self.move((diff, 0))
 
-    def getRightMargin(self, layer: Optional["Layer"] = None) -> Optional[float]:
+    def getRightMargin(self, layer: Optional[GlyphSet] = None) -> Optional[float]:
         """Returns the the space in font units from the glyph's advance width
         to the right side of the glyph.
 
@@ -491,7 +478,7 @@ class Glyph:
             return None
         return self.width - bounds.xMax
 
-    def setRightMargin(self, value: float, layer: Optional["Layer"] = None) -> None:
+    def setRightMargin(self, value: float, layer: Optional[GlyphSet] = None) -> None:
         """Sets the the space in font units from the glyph's advance width to
         the right side of the glyph.
 
@@ -505,7 +492,7 @@ class Glyph:
             return None
         self.width = bounds.xMax + value
 
-    def getBottomMargin(self, layer: Optional["Layer"] = None) -> Optional[float]:
+    def getBottomMargin(self, layer: Optional[GlyphSet] = None) -> Optional[float]:
         """Returns the the space in font units from the bottom of the canvas to
         the bottom of the glyph.
 
@@ -521,7 +508,7 @@ class Glyph:
         else:
             return bounds.yMin - (self.verticalOrigin - self.height)
 
-    def setBottomMargin(self, value: float, layer: Optional["Layer"] = None) -> None:
+    def setBottomMargin(self, value: float, layer: Optional[GlyphSet] = None) -> None:
         """Sets the the space in font units from the bottom of the canvas to
         the bottom of the glyph.
 
@@ -543,7 +530,7 @@ class Glyph:
         if diff:
             self.height += diff
 
-    def getTopMargin(self, layer: Optional["Layer"] = None) -> Optional[float]:
+    def getTopMargin(self, layer: Optional[GlyphSet] = None) -> Optional[float]:
         """Returns the the space in font units from the top of the canvas to
         the top of the glyph.
 
@@ -559,7 +546,7 @@ class Glyph:
         else:
             return self.verticalOrigin - bounds.yMax
 
-    def setTopMargin(self, value: float, layer: Optional["Layer"] = None) -> None:
+    def setTopMargin(self, value: float, layer: Optional[GlyphSet] = None) -> None:
         """Sets the the space in font units from the top of the canvas to the
         top of the glyph.
 

--- a/src/ufoLib2/objects/layer.py
+++ b/src/ufoLib2/objects/layer.py
@@ -148,7 +148,7 @@ class Layer:
 
     __deepcopy__ = _deepcopy_unlazify_attrs
 
-    def __contains__(self, name: str) -> bool:
+    def __contains__(self, name: object) -> bool:
         return name in self._glyphs
 
     def __delitem__(self, name: str) -> None:

--- a/src/ufoLib2/objects/misc.py
+++ b/src/ufoLib2/objects/misc.py
@@ -24,7 +24,7 @@ from fontTools.pens.boundsPen import BoundsPen, ControlBoundsPen
 from fontTools.ufoLib import UFOReader, UFOWriter
 
 from ufoLib2.constants import OBJECT_LIBS_KEY
-from ufoLib2.typing import Drawable, HasIdentifier
+from ufoLib2.typing import Drawable, GlyphSet, HasIdentifier
 
 
 class BoundingBox(NamedTuple):
@@ -36,9 +36,7 @@ class BoundingBox(NamedTuple):
     yMax: float
 
 
-def getBounds(drawable: Drawable, layer: Any) -> Optional[BoundingBox]:
-    # XXX: layer should behave like a mapping of glyph names to Glyph objects, but
-    # cyclic imports...
+def getBounds(drawable: Drawable, layer: Optional[GlyphSet]) -> Optional[BoundingBox]:
     pen = BoundsPen(layer)
     # raise 'KeyError' when a referenced component is missing from glyph set
     pen.skipMissingComponents = False
@@ -46,9 +44,9 @@ def getBounds(drawable: Drawable, layer: Any) -> Optional[BoundingBox]:
     return None if pen.bounds is None else BoundingBox(*pen.bounds)
 
 
-def getControlBounds(drawable: Drawable, layer: Any) -> Optional[BoundingBox]:
-    # XXX: layer should behave like a mapping of glyph names to Glyph objects, but
-    # cyclic imports...
+def getControlBounds(
+    drawable: Drawable, layer: Optional[GlyphSet]
+) -> Optional[BoundingBox]:
     pen = ControlBoundsPen(layer)
     # raise 'KeyError' when a referenced component is missing from glyph set
     pen.skipMissingComponents = False

--- a/src/ufoLib2/typing.py
+++ b/src/ufoLib2/typing.py
@@ -3,6 +3,7 @@ import sys
 from typing import Optional, TypeVar, Union
 
 from fontTools.pens.basePen import AbstractPen
+from fontTools.pens.pointPen import AbstractPointPen
 
 if sys.version_info >= (3, 8):
     from typing import Protocol
@@ -27,8 +28,38 @@ class Drawable(Protocol):
         ...
 
 
+class DrawablePoints(Protocol):
+    """Stand-in for an object that can draw its points with a given pen.
+
+    See :mod:`fontTools.pens.pointPen` for an introduction to point pens.
+    """
+
+    def drawPoints(self, pen: AbstractPointPen) -> None:
+        ...
+
+
 class HasIdentifier(Protocol):
     """Any object that has a unique identifier in some context that can be
     used as a key in a public.objectLibs dictionary."""
 
     identifier: Optional[str]
+
+
+class GlyphSet(Protocol):
+    """Any container that holds drawable objects.
+
+    In ufoLib2, this usually refers to :class:`.Font` (referencing glyphs in the
+    default layer) and :class:`.Layer` (referencing glyphs in that particular layer).
+    Ideally, this would be a simple subclass of ``Mapping[str, Union[Drawable, DrawablePoints]]``,
+    but due to historic reasons, the established objects don't conform to ``Mapping``
+    exactly.
+
+    The protocol contains what is used in :mod:`fontTools.pens` at v4.18.2
+    (grep for ``.glyphSet``).
+    """
+
+    def __contains__(self, name: object) -> bool:
+        ...
+
+    def __getitem__(self, name: str) -> Union[Drawable, DrawablePoints]:
+        ...


### PR DESCRIPTION
More elegant than referring to Layer and Glyph explicitly, which nicely avoids circular imports.

Closes https://github.com/fonttools/ufoLib2/issues/110.