### PR TITLE
Use iondrive acceleration library if available

### DIFF
--- a/src/ufoLib2/objects/font.py
+++ b/src/ufoLib2/objects/font.py
@@ -178,7 +178,9 @@ class Font:
                 self._reader = reader
 
     @classmethod
-    def open(cls, path: PathLike, lazy: bool = True, validate: bool = True) -> "Font":
+    def open(
+        cls, path: PathLike, lazy: bool = True, validate: bool = True, loader=None
+    ) -> "Font":
         """Instantiates a new Font object from a path to a UFO.
 
         Args:
@@ -187,7 +189,12 @@ class Font:
                 False, load everything up front.
             validate: If True, enable UFO data model validation during loading. If
                 False, load whatever is deserializable.
+            loader: A function to call to load the font. The function is passed the
+                `ufoLib2.objects` module and the font path.
+
         """
+        if loader:
+            return loader(ufoLib2.objects, path)
         reader = UFOReader(path, validate=validate)
         self = cls.read(reader, lazy=lazy)
         self._path = path

--- a/src/ufoLib2/objects/font.py
+++ b/src/ufoLib2/objects/font.py
@@ -1,7 +1,9 @@
 import os
 import shutil
+from types import ModuleType
 from typing import (
     Any,
+    Callable,
     Dict,
     Iterable,
     Iterator,
@@ -20,6 +22,7 @@ import fs.base
 import fs.tempfs
 from fontTools.ufoLib import UFOFileStructure, UFOReader, UFOWriter
 
+from ufoLib2 import objects
 from ufoLib2.constants import DEFAULT_LAYER_NAME
 from ufoLib2.objects.dataSet import DataSet
 from ufoLib2.objects.features import Features
@@ -179,7 +182,11 @@ class Font:
 
     @classmethod
     def open(
-        cls, path: PathLike, lazy: bool = True, validate: bool = True, loader=None
+        cls,
+        path: PathLike,
+        lazy: bool = True,
+        validate: bool = True,
+        loader: Optional[Callable[[ModuleType, PathLike], "Font"]] = None,
     ) -> "Font":
         """Instantiates a new Font object from a path to a UFO.
 
@@ -194,7 +201,7 @@ class Font:
 
         """
         if loader:
-            return loader(ufoLib2.objects, path)
+            return loader(objects, path)
         reader = UFOReader(path, validate=validate)
         self = cls.read(reader, lazy=lazy)
         self._path = path


### PR DESCRIPTION
iondrive creates ufoLib2 objects using norad, for faster up UFO loading. It isn't a full wrapper, just a fake around the load() function.

```python3
import iondrive, timeit, ufoLib2

path = "master_ufo/NotoSerif-Regular.ufo"

def dowork(font):
    for g in font:
        a = g.getBounds(font.layers.defaultLayer)

def ufotest():
    dowork(ufoLib2.Font.open(path))

def iontest():
    dowork(iondrive.load(ufoLib2.objects,path))

print("ufolib2 time: %f" % timeit.timeit(ufotest, number = 10))
print("iondrive: %f" % timeit.timeit(iontest, number = 10))
```

```
$ python3 timetest.py
ufolib2 time: 15.661078
iondrive: 5.660718
```

This PR tests if iondrive is available and uses it if so.
