### PR TITLE
Do not require wheel for all setuptools operations

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ packages = find:
 python_requires = >=3.6
 setup_requires =
     setuptools_scm
-    wheel
 install_requires =
     attrs >= 19.2.0
     fonttools[ufo] >= 4.0.0


### PR DESCRIPTION
Fixes #156

When using setuptools (commonly still used for distro packages because no other solution supports installing to bare packaging directory yet) to build a project it is not necessary or desired to have *wheel* in the loop. It is needed for releasing the project upstream of course, but not for installing it locally.