### PR TITLE
Don't compare private Font attributes

### DIFF
--- a/src/ufoLib2/objects/font.py
+++ b/src/ufoLib2/objects/font.py
@@ -117,7 +117,9 @@ class Font:
         default layer.
     """
 
-    _path: Optional[PathLike] = attr.ib(default=None, metadata=dict(copyable=False))
+    _path: Optional[PathLike] = attr.ib(
+        default=None, metadata=dict(copyable=False), cmp=False
+    )
 
     layers: LayerSet = attr.ib(
         factory=LayerSet.default,
@@ -152,11 +154,15 @@ class Font:
     )
     """ImageSet: A mapping of image file paths to arbitrary image data."""
 
-    _lazy: Optional[bool] = attr.ib(default=None, kw_only=True)
-    _validate: bool = attr.ib(default=True, kw_only=True)
+    _lazy: Optional[bool] = attr.ib(default=None, kw_only=True, cmp=False)
+    _validate: bool = attr.ib(default=True, kw_only=True, cmp=False)
 
-    _reader: Optional[UFOReader] = attr.ib(default=None, kw_only=True, init=False)
-    _fileStructure: Optional[UFOFileStructure] = attr.ib(default=None, init=False)
+    _reader: Optional[UFOReader] = attr.ib(
+        default=None, kw_only=True, init=False, cmp=False
+    )
+    _fileStructure: Optional[UFOFileStructure] = attr.ib(
+        default=None, init=False, cmp=False
+    )
 
     def __attrs_post_init__(self) -> None:
         if self._path is not None:


### PR DESCRIPTION
They clog up pytest's assert display and contribute no semantics to a Font.

Note that the custom `Font.__eq__` method already takes care not to use these fields for equality testing, but this is more about the fields showing up in pytest's custom assert failure report for `assert font1 == font2` where they serve no purpose.