### PR TITLE
less boilerplate using attrs' next-gen API

### DIFF
--- a/src/ufoLib2/objects/anchor.py
+++ b/src/ufoLib2/objects/anchor.py
@@ -1,11 +1,11 @@
 from typing import Optional, Tuple
 
-import attr
+from attr import define
 
 from ufoLib2.objects.misc import AttrDictMixin
 
 
-@attr.s(auto_attribs=True, slots=True)
+@define
 class Anchor(AttrDictMixin):
     """Represents a single anchor.
 

--- a/src/ufoLib2/objects/component.py
+++ b/src/ufoLib2/objects/component.py
@@ -1,7 +1,7 @@
 import warnings
 from typing import Optional, Tuple
 
-import attr
+from attr import define, field
 from fontTools.misc.transform import Identity, Transform
 from fontTools.pens.basePen import AbstractPen
 from fontTools.pens.pointPen import AbstractPointPen, PointToSegmentPen
@@ -12,7 +12,7 @@ from ufoLib2.typing import GlyphSet
 from .misc import _convert_transform, getBounds, getControlBounds
 
 
-@attr.s(auto_attribs=True, slots=True)
+@define
 class Component:
     """Represents a reference to another glyph in the same layer.
 
@@ -26,7 +26,7 @@ class Component:
     baseGlyph: str
     """The name of the glyph in the same layer to insert."""
 
-    transformation: Transform = attr.ib(default=Identity, converter=_convert_transform)
+    transformation: Transform = field(default=Identity, converter=_convert_transform)
     """The affine transformation to apply to the :attr:`.Component.baseGlyph`."""
 
     identifier: Optional[str] = None

--- a/src/ufoLib2/objects/contour.py
+++ b/src/ufoLib2/objects/contour.py
@@ -2,7 +2,7 @@ import warnings
 from collections.abc import MutableSequence
 from typing import Iterable, Iterator, List, Optional, Tuple, Union, overload
 
-import attr
+from attr import define, field
 from fontTools.pens.basePen import AbstractPen
 from fontTools.pens.pointPen import AbstractPointPen, PointToSegmentPen
 
@@ -11,7 +11,7 @@ from ufoLib2.objects.point import Point
 from ufoLib2.typing import GlyphSet
 
 
-@attr.s(auto_attribs=True, slots=True)
+@define
 class Contour(MutableSequence):
     """Represents a contour as a list of points.
 
@@ -39,10 +39,10 @@ class Contour(MutableSequence):
             contour[0] = anotherPoint
     """
 
-    points: List[Point] = attr.ib(factory=list)
+    points: List[Point] = field(factory=list)
     """The list of points in the contour."""
 
-    identifier: Optional[str] = attr.ib(default=None, repr=False)
+    identifier: Optional[str] = field(default=None, repr=False)
     """The globally unique identifier of the contour."""
 
     # collections.abc.MutableSequence interface

--- a/src/ufoLib2/objects/features.py
+++ b/src/ufoLib2/objects/features.py
@@ -1,7 +1,7 @@
-import attr
+from attr import define
 
 
-@attr.s(auto_attribs=True, slots=True)
+@define
 class Features:
     """A data class representing UFO features.
 

--- a/src/ufoLib2/objects/font.py
+++ b/src/ufoLib2/objects/font.py
@@ -16,9 +16,9 @@ from typing import (
 )
 
 import attr
-import fs
 import fs.base
 import fs.tempfs
+from attr import define, field
 from fontTools.ufoLib import UFOFileStructure, UFOReader, UFOWriter
 
 from ufoLib2.constants import DEFAULT_LAYER_NAME
@@ -55,7 +55,7 @@ def _convert_Features(value: Union[Features, str]) -> Features:
     return value if isinstance(value, Features) else Features(value)
 
 
-@attr.s(auto_attribs=True, slots=True, repr=False, eq=False)
+@define
 class Font:
     """A data class representing a single Unified Font Object (UFO).
 
@@ -118,51 +118,51 @@ class Font:
         default layer.
     """
 
-    _path: Optional[PathLike] = attr.ib(
-        default=None, metadata=dict(copyable=False), cmp=False
+    _path: Optional[PathLike] = field(
+        default=None, metadata=dict(copyable=False), eq=False
     )
 
-    layers: LayerSet = attr.ib(
+    layers: LayerSet = field(
         factory=LayerSet.default,
         validator=attr.validators.instance_of(LayerSet),
         kw_only=True,
     )
     """LayerSet: A mapping of layer names to Layer objects."""
 
-    info: Info = attr.ib(factory=Info, converter=_convert_Info, kw_only=True)
+    info: Info = field(factory=Info, converter=_convert_Info, kw_only=True)
     """Info: The font Info object."""
 
-    features: Features = attr.ib(
+    features: Features = field(
         factory=Features, converter=_convert_Features, kw_only=True
     )
     """Features: The font Features object."""
 
-    groups: Dict[str, List[str]] = attr.ib(factory=dict, kw_only=True)
+    groups: Dict[str, List[str]] = field(factory=dict, kw_only=True)
     """Dict[str, List[str]]: A mapping of group names to a list of glyph names."""
 
-    kerning: Dict[Tuple[str, str], float] = attr.ib(factory=dict, kw_only=True)
+    kerning: Dict[Tuple[str, str], float] = field(factory=dict, kw_only=True)
     """Dict[Tuple[str, str], float]: A mapping of a tuple of first and second kerning
     pair to a kerning value."""
 
-    lib: Dict[str, Any] = attr.ib(factory=dict, kw_only=True)
+    lib: Dict[str, Any] = field(factory=dict, kw_only=True)
     """Dict[str, Any]: A mapping of keys to arbitrary values."""
 
-    data: DataSet = attr.ib(factory=DataSet, converter=_convert_DataSet, kw_only=True)
+    data: DataSet = field(factory=DataSet, converter=_convert_DataSet, kw_only=True)
     """DataSet: A mapping of data file paths to arbitrary data."""
 
-    images: ImageSet = attr.ib(
+    images: ImageSet = field(
         factory=ImageSet, converter=_convert_ImageSet, kw_only=True
     )
     """ImageSet: A mapping of image file paths to arbitrary image data."""
 
-    _lazy: Optional[bool] = attr.ib(default=None, kw_only=True, cmp=False)
-    _validate: bool = attr.ib(default=True, kw_only=True, cmp=False)
+    _lazy: Optional[bool] = field(default=None, kw_only=True, eq=False)
+    _validate: bool = field(default=True, kw_only=True, eq=False)
 
-    _reader: Optional[UFOReader] = attr.ib(
-        default=None, kw_only=True, init=False, cmp=False
+    _reader: Optional[UFOReader] = field(
+        default=None, kw_only=True, init=False, eq=False
     )
-    _fileStructure: Optional[UFOFileStructure] = attr.ib(
-        default=None, init=False, cmp=False
+    _fileStructure: Optional[UFOFileStructure] = field(
+        default=None, init=False, eq=False
     )
 
     def __attrs_post_init__(self) -> None:

--- a/src/ufoLib2/objects/glyph.py
+++ b/src/ufoLib2/objects/glyph.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from typing import Any, Dict, Iterator, List, Mapping, Optional, Tuple, Union
 
-import attr
+from attr import define, field
 from fontTools.misc.transform import Transform
 from fontTools.pens.basePen import AbstractPen
 from fontTools.pens.pointPen import (
@@ -20,7 +20,7 @@ from ufoLib2.pointPens.glyphPointPen import GlyphPointPen
 from ufoLib2.typing import GlyphSet, HasIdentifier
 
 
-@attr.s(auto_attribs=True, slots=True, repr=False)
+@define
 class Glyph:
     """Represents a glyph, containing contours, components, anchors and various
     other bits of data concerning it.
@@ -58,26 +58,26 @@ class Glyph:
     height: float = 0
     """The height of the glyph."""
 
-    unicodes: List[int] = attr.ib(factory=list)
+    unicodes: List[int] = field(factory=list)
     """The Unicode code points assigned to the glyph. Note that a glyph can have
     multiple."""
 
-    _image: Image = attr.ib(factory=Image)
+    _image: Image = field(factory=Image)
 
-    lib: Dict[str, Any] = attr.ib(factory=dict)
+    lib: Dict[str, Any] = field(factory=dict)
     """The glyph's mapping of string keys to arbitrary data."""
 
     note: Optional[str] = None
     """A free form text note about the glyph."""
 
-    _anchors: List[Anchor] = attr.ib(factory=list)
-    components: List[Component] = attr.ib(factory=list)
+    _anchors: List[Anchor] = field(factory=list)
+    components: List[Component] = field(factory=list)
     """The list of components the glyph contains."""
 
-    contours: List[Contour] = attr.ib(factory=list)
+    contours: List[Contour] = field(factory=list)
     """The list of contours the glyph contains."""
 
-    _guidelines: List[Guideline] = attr.ib(factory=list)
+    _guidelines: List[Guideline] = field(factory=list)
 
     def __len__(self) -> int:
         return len(self.contours)

--- a/src/ufoLib2/objects/guideline.py
+++ b/src/ufoLib2/objects/guideline.py
@@ -1,11 +1,11 @@
 from typing import Optional
 
-import attr
+from attr import define
 
 from ufoLib2.objects.misc import AttrDictMixin
 
 
-@attr.s(auto_attribs=True, slots=True)
+@define
 class Guideline(AttrDictMixin):
     """Represents a single guideline.
 

--- a/src/ufoLib2/objects/image.py
+++ b/src/ufoLib2/objects/image.py
@@ -1,13 +1,13 @@
 from collections.abc import Mapping
 from typing import Any, Iterator, Optional, Tuple
 
-import attr
+from attr import define, field
 from fontTools.misc.transform import Identity, Transform
 
 from .misc import _convert_transform
 
 
-@attr.s(auto_attribs=True, slots=True)
+@define
 class Image(Mapping):
     """Represents a background image reference.
 
@@ -18,7 +18,7 @@ class Image(Mapping):
     fileName: Optional[str] = None
     """The filename of the image."""
 
-    transformation: Transform = attr.ib(default=Identity, converter=_convert_transform)
+    transformation: Transform = field(default=Identity, converter=_convert_transform)
     """The affine transformation applied to the image."""
 
     color: Optional[str] = None

--- a/src/ufoLib2/objects/info.py
+++ b/src/ufoLib2/objects/info.py
@@ -2,6 +2,7 @@ from enum import IntEnum
 from typing import Any, List, Optional, Sequence, Type, TypeVar, Union
 
 import attr
+from attr import define, field
 from fontTools.ufoLib import UFOReader
 
 from ufoLib2.objects.guideline import Guideline
@@ -36,19 +37,19 @@ def _convert_GaspBehavior(
     return [v if isinstance(v, GaspBehavior) else GaspBehavior(v) for v in seq]
 
 
-@attr.s(auto_attribs=True, slots=True)
+@define
 class GaspRangeRecord(AttrDictMixin):
-    rangeMaxPPEM: int = attr.ib(validator=_positive)
+    rangeMaxPPEM: int = field(validator=_positive)
     # Use Set[GaspBehavior] instead of List?
-    rangeGaspBehavior: List[GaspBehavior] = attr.ib(converter=_convert_GaspBehavior)
+    rangeGaspBehavior: List[GaspBehavior] = field(converter=_convert_GaspBehavior)
 
 
-@attr.s(auto_attribs=True, slots=True)
+@define
 class NameRecord(AttrDictMixin):
-    nameID: int = attr.ib(validator=_positive)
-    platformID: int = attr.ib(validator=_positive)
-    encodingID: int = attr.ib(validator=_positive)
-    languageID: int = attr.ib(validator=_positive)
+    nameID: int = field(validator=_positive)
+    platformID: int = field(validator=_positive)
+    encodingID: int = field(validator=_positive)
+    languageID: int = field(validator=_positive)
     string: str = ""
 
 
@@ -104,7 +105,7 @@ def _convert_WidthClass(value: Optional[int]) -> Optional[WidthClass]:
     return None if value is None else WidthClass(value)
 
 
-@attr.s(auto_attribs=True, slots=True)
+@define
 class Info:
     """A data class representing the contents of fontinfo.plist.
 
@@ -117,13 +118,13 @@ class Info:
     styleName: Optional[str] = None
     styleMapFamilyName: Optional[str] = None
     styleMapStyleName: Optional[str] = None
-    versionMajor: Optional[int] = attr.ib(default=None, validator=_optional_positive)
-    versionMinor: Optional[int] = attr.ib(default=None, validator=_optional_positive)
+    versionMajor: Optional[int] = field(default=None, validator=_optional_positive)
+    versionMinor: Optional[int] = field(default=None, validator=_optional_positive)
 
     copyright: Optional[str] = None
     trademark: Optional[str] = None
 
-    unitsPerEm: Optional[float] = attr.ib(default=None, validator=_optional_positive)
+    unitsPerEm: Optional[float] = field(default=None, validator=_optional_positive)
     descender: Optional[float] = None
     xHeight: Optional[float] = None
     capHeight: Optional[float] = None
@@ -132,7 +133,7 @@ class Info:
 
     note: Optional[str] = None
 
-    _guidelines: Optional[List[Guideline]] = attr.ib(
+    _guidelines: Optional[List[Guideline]] = field(
         default=None, converter=_convert_guidelines
     )
 
@@ -144,7 +145,7 @@ class Info:
     def guidelines(self, value: Optional[List[Guideline]]) -> None:
         self._guidelines = _convert_guidelines(value)
 
-    _openTypeGaspRangeRecords: Optional[List[GaspRangeRecord]] = attr.ib(
+    _openTypeGaspRangeRecords: Optional[List[GaspRangeRecord]] = field(
         default=None, converter=_convert_gasp_range_records
     )
 
@@ -157,7 +158,7 @@ class Info:
         self._openTypeGaspRangeRecords = _convert_gasp_range_records(value)
 
     openTypeHeadCreated: Optional[str] = None
-    openTypeHeadLowestRecPPEM: Optional[int] = attr.ib(
+    openTypeHeadLowestRecPPEM: Optional[int] = field(
         default=None, validator=_optional_positive
     )
     openTypeHeadFlags: Optional[List[int]] = None
@@ -185,7 +186,7 @@ class Info:
     openTypeNameWWSFamilyName: Optional[str] = None
     openTypeNameWWSSubfamilyName: Optional[str] = None
 
-    _openTypeNameRecords: Optional[List[NameRecord]] = attr.ib(
+    _openTypeNameRecords: Optional[List[NameRecord]] = field(
         default=None, converter=_convert_name_records
     )
 
@@ -197,7 +198,7 @@ class Info:
     def openTypeNameRecords(self, value: Optional[List[NameRecord]]) -> None:
         self._openTypeNameRecords = _convert_name_records(value)
 
-    _openTypeOS2WidthClass: Optional[WidthClass] = attr.ib(
+    _openTypeOS2WidthClass: Optional[WidthClass] = field(
         default=None, converter=_convert_WidthClass
     )
 
@@ -209,7 +210,7 @@ class Info:
     def openTypeOS2WidthClass(self, value: Optional[WidthClass]) -> None:
         self._openTypeOS2WidthClass = value if value is None else WidthClass(value)
 
-    openTypeOS2WeightClass: Optional[int] = attr.ib(default=None)
+    openTypeOS2WeightClass: Optional[int] = field(default=None)
 
     @openTypeOS2WeightClass.validator
     def _validate_weight_class(self, attribute: Any, value: Optional[int]) -> None:
@@ -225,10 +226,10 @@ class Info:
     openTypeOS2TypoAscender: Optional[int] = None
     openTypeOS2TypoDescender: Optional[int] = None
     openTypeOS2TypoLineGap: Optional[int] = None
-    openTypeOS2WinAscent: Optional[int] = attr.ib(
+    openTypeOS2WinAscent: Optional[int] = field(
         default=None, validator=_optional_positive
     )
-    openTypeOS2WinDescent: Optional[int] = attr.ib(
+    openTypeOS2WinDescent: Optional[int] = field(
         default=None, validator=_optional_positive
     )
     openTypeOS2Type: Optional[List[int]] = None

--- a/src/ufoLib2/objects/layer.py
+++ b/src/ufoLib2/objects/layer.py
@@ -10,7 +10,7 @@ from typing import (
     overload,
 )
 
-import attr
+from attr import define, field
 from fontTools.ufoLib.glifLib import GlyphSet
 
 from ufoLib2.constants import DEFAULT_LAYER_NAME
@@ -64,7 +64,7 @@ def _convert_glyphs(
     return result
 
 
-@attr.s(auto_attribs=True, slots=True, repr=False)
+@define
 class Layer:
     """Represents a Layer that holds Glyph objects.
 
@@ -103,16 +103,16 @@ class Layer:
     """
 
     _name: str = DEFAULT_LAYER_NAME
-    _glyphs: Dict[str, Union[Glyph, Placeholder]] = attr.ib(
+    _glyphs: Dict[str, Union[Glyph, Placeholder]] = field(
         factory=dict, converter=_convert_glyphs
     )
     color: Optional[str] = None
     """The color assigned to the layer."""
 
-    lib: Dict[str, Any] = attr.ib(factory=dict)
+    lib: Dict[str, Any] = field(factory=dict)
     """The layer's lib for mapping string keys to arbitrary data."""
 
-    _glyphSet: Any = attr.ib(default=None, init=False, eq=False)
+    _glyphSet: Any = field(default=None, init=False, eq=False)
 
     @classmethod
     def read(cls, name: str, glyphSet: GlyphSet, lazy: bool = True) -> "Layer":

--- a/src/ufoLib2/objects/layerSet.py
+++ b/src/ufoLib2/objects/layerSet.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 from typing import AbstractSet, Any, Iterable, Iterator, List, Optional, Sized, Union
 
-import attr
+from attr import define, field
 from fontTools.ufoLib import UFOReader, UFOWriter
 
 from ufoLib2.constants import DEFAULT_LAYER_NAME
@@ -16,7 +16,7 @@ def _must_have_at_least_one_item(self: Any, attribute: Any, value: Sized) -> Non
         raise ValueError("value must have at least one item.")
 
 
-@attr.s(auto_attribs=True, slots=True, repr=False)
+@define
 class LayerSet:
     """Represents a mapping of layer names to Layer objects.
 
@@ -51,14 +51,14 @@ class LayerSet:
             del font.layers["myLayerName"]
     """
 
-    _layers: "OrderedDict[str, Union[Layer, Placeholder]]" = attr.ib(
+    _layers: "OrderedDict[str, Union[Layer, Placeholder]]" = field(
         validator=_must_have_at_least_one_item,
     )
 
     defaultLayer: Layer
     """The Layer that is marked as the default, typically named ``public.default``."""
 
-    _reader: Optional[UFOReader] = attr.ib(default=None, init=False, eq=False)
+    _reader: Optional[UFOReader] = field(default=None, init=False, eq=False)
 
     def __attrs_post_init__(self) -> None:
         if not any(layer is self.defaultLayer for layer in self._layers.values()):

--- a/src/ufoLib2/objects/misc.py
+++ b/src/ufoLib2/objects/misc.py
@@ -19,6 +19,7 @@ from typing import (
 )
 
 import attr
+from attr import define, field
 from fontTools.misc.arrayTools import unionRect
 from fontTools.misc.transform import Transform
 from fontTools.pens.boundsPen import BoundsPen, ControlBoundsPen
@@ -126,7 +127,7 @@ _NOT_LOADED = Placeholder()
 Tds = TypeVar("Tds", bound="DataStore")
 
 
-@attr.s(auto_attribs=True, slots=True, repr=False, eq=False)
+@define
 class DataStore(MutableMapping):
     """Represents the base class for ImageSet and DataSet.
 
@@ -134,14 +135,12 @@ class DataStore(MutableMapping):
     differ in which reader and writer methods they call.
     """
 
-    _data: Dict[str, Union[bytes, Placeholder]] = attr.ib(factory=dict)
+    _data: Dict[str, Union[bytes, Placeholder]] = field(factory=dict)
 
-    _lazy: Optional[bool] = attr.ib(default=False, kw_only=True, cmp=False, init=False)
-    _reader: Optional[UFOReader] = attr.ib(
-        default=None, init=False, repr=False, cmp=False
-    )
-    _scheduledForDeletion: Set[str] = attr.ib(
-        factory=set, init=False, repr=False, cmp=False
+    _lazy: Optional[bool] = field(default=False, kw_only=True, eq=False, init=False)
+    _reader: Optional[UFOReader] = field(default=None, init=False, repr=False, eq=False)
+    _scheduledForDeletion: Set[str] = field(
+        factory=set, init=False, repr=False, eq=False
     )
 
     def __eq__(self, other: object) -> bool:

--- a/src/ufoLib2/objects/point.py
+++ b/src/ufoLib2/objects/point.py
@@ -1,9 +1,9 @@
 from typing import Optional, Tuple
 
-import attr
+from attr import define
 
 
-@attr.s(auto_attribs=True, slots=True)
+@define
 class Point:
     """Represents a single point.
 


### PR DESCRIPTION
https://www.attrs.org/en/stable/api.html#next-generation-apis is now [stable](https://www.attrs.org/en/stable/changelog.html#deprecations), so we may as well start using it.
I think using `@define` and `field()` look nicer than `@attr.s` and `attr.ib()`. Also the new defaults make more sense:

> automatically detect whether or not auto_attribs should be True
slots=True
auto_exc=True
auto_detect=True
eq=True, but order=False
Validators run when you set an attribute (on_setattr=attr.setters.validate).