### PR TITLE
remove legacy Font(path), require one does Font.open(path)

### DIFF
--- a/tests/test_ufoLib2.py
+++ b/tests/test_ufoLib2.py
@@ -50,25 +50,6 @@ def test_lazy_data_loading_inplace_load_some(ufo_UbuTestData):
     assert ufo.data["com.github.fonttools.ttx/T_S_I__0.ttx"] == some_data
 
 
-def test_constructor_from_path(datadir):
-    path = datadir / "UbuTestData.ufo"
-    font = ufoLib2.Font(path)
-
-    assert font._path == path
-    assert font._lazy is True
-    assert font._validate is True
-    assert font._reader is not None
-
-    font2 = ufoLib2.Font(path, lazy=False, validate=False)
-
-    assert font2._path == path
-    assert font2._lazy is False
-    assert font2._validate is False
-    assert font2._reader is None
-
-    assert font == font2
-
-
 def test_deepcopy_lazy_object(datadir):
     path = datadir / "UbuTestData.ufo"
     font1 = ufoLib2.Font.open(path, lazy=True)


### PR DESCRIPTION
`ufoLib2.Font` is a data-class the models the contents of a UFO, one that can exist in memory only and be pieced together from code or deserialized from data coming from elsewhere than a UFO sitting on the filesystem. Thus, the `path` parameter (along with related `lazy` or `validate`) doesn't belong to its default `__init__` constructor, but only to `Font.open` or `Font.read` alternate classmethod constructors.
`Font(path)` never actually fitted ufoLib2's data-class model, it was only introduced to mimic pre-existing APIs like robofab or defcon, but we no longer need that for our font build pipeline.