### PR TITLE
add property setter for Font.kerning to coerce dict to Kerning class

### DIFF
--- a/src/ufoLib2/objects/font.py
+++ b/src/ufoLib2/objects/font.py
@@ -65,6 +65,14 @@ def _convert_Kerning(value: Mapping[KerningPair, float]) -> Kerning:
     return value if isinstance(value, Kerning) else Kerning(value)
 
 
+def _get_kerning(self: Font) -> Kerning:
+    return self._kerning
+
+
+def _set_kerning(self: Font, value: Mapping[KerningPair, float]) -> None:
+    self._kerning = _convert_Kerning(value)
+
+
 @define(kw_only=True)
 class Font:
     """A data class representing a single Unified Font Object (UFO).
@@ -141,7 +149,7 @@ class Font:
     groups: Dict[str, List[str]] = field(factory=dict)
     """Dict[str, List[str]]: A mapping of group names to a list of glyph names."""
 
-    kerning: Kerning = field(factory=Kerning, converter=_convert_Kerning)
+    _kerning: Kerning = field(factory=Kerning, converter=_convert_Kerning)
     """Dict[Tuple[str, str], float]: A mapping of a tuple of first and second kerning
     pair to a kerning value."""
 
@@ -358,6 +366,8 @@ class Font:
         self.info.guidelines = []
         for guideline in value:
             self.appendGuideline(guideline)
+
+    kerning = property(_get_kerning, _set_kerning)
 
     lib = property(_get_lib, _set_lib)
 

--- a/tests/test_ufoLib2.py
+++ b/tests/test_ufoLib2.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from copy import deepcopy
 from pathlib import Path
+from typing import Any, Type
 
 import pytest
 from fontTools import ufoLib
 
 import ufoLib2
 import ufoLib2.objects
-from ufoLib2.objects import Features, Font, Layer, LayerSet
+from ufoLib2.objects import Features, Font, Glyph, Kerning, Layer, LayerSet, Lib
 from ufoLib2.objects.layerSet import _LAYER_NOT_LOADED
 from ufoLib2.objects.misc import _DATA_NOT_LOADED
 
@@ -265,3 +266,21 @@ def test_woff_metadata(datadir: Path, tmp_path: Path) -> None:
 
 def test_features_normalize_newlines() -> None:
     assert Features("a\r\nb\rc\n").normalize_newlines().text == "a\nb\nc\n"
+
+
+@pytest.mark.parametrize(
+    "klass, attr_name, attr_type, obj",
+    [
+        (Font, "lib", Lib, {"foo": 1}),
+        (Font, "kerning", Kerning, {("a", "b"): -10}),
+        (Glyph, "lib", Lib, {"bar": [2, 3]}),
+    ],
+)
+def test_convert_on_setattr(
+    klass: Type[Any], attr_name: str, attr_type: Type[Any], obj: Any
+) -> None:
+    o = klass()
+    assert isinstance(getattr(o, attr_name), attr_type)
+    assert not isinstance(obj, attr_type)
+    setattr(o, attr_name, obj)
+    assert isinstance(getattr(o, attr_name), attr_type)


### PR DESCRIPTION
This is to continue supporting `font.kerning = {(a, b): -10, ...}` even after we typed Font.kerning as `Kerning` dict subclass (to customize (un)structuring via cattrs in #181).

Alternative to #188 