### PR TITLE
export structure/unstructure public methods using default_converter

### DIFF
--- a/src/ufoLib2/converters.py
+++ b/src/ufoLib2/converters.py
@@ -26,8 +26,9 @@ else:
 
 
 __all__ = [
-    "default_converter",
     "register_hooks",
+    "structure",
+    "unstructure",
 ]
 
 
@@ -139,3 +140,6 @@ default_converter = GenConverter(
     prefer_attrib_converters=False,
 )
 register_hooks(default_converter, allow_bytes=False)
+
+structure = default_converter.structure
+unstructure = default_converter.unstructure

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -49,7 +49,7 @@ from ufoLib2.objects.info import (
 
 # isort: off
 cattr = pytest.importorskip("cattr")
-from ufoLib2.converters import default_converter, register_hooks  # noqa: E402
+from ufoLib2.converters import register_hooks, structure, unstructure  # noqa: E402
 
 
 @pytest.mark.parametrize(
@@ -499,17 +499,17 @@ from ufoLib2.converters import default_converter, register_hooks  # noqa: E402
     ],
 )
 def test_unstructure_structure(obj: Any, expected: dict[str, Any]) -> None:
-    assert default_converter.unstructure(obj) == expected
-    assert default_converter.structure(expected, type(obj)) == obj
+    assert unstructure(obj) == expected
+    assert structure(expected, type(obj)) == obj
 
 
 def test_unstructure_lazy_font(ufo_UbuTestData: Font) -> None:
     font1 = ufo_UbuTestData
     assert font1._lazy
 
-    font_data = default_converter.unstructure(font1)
+    font_data = unstructure(font1)
 
-    font2 = default_converter.structure(font_data, Font)
+    font2 = structure(font_data, Font)
     assert font2 == font1
 
     assert not font2._lazy
@@ -683,7 +683,7 @@ def test_json_dumps(datadir: pathlib.Path) -> None:
     # opening the UFO on Windows
     font.features.normalize_newlines()
 
-    data = default_converter.unstructure(font)
+    data = unstructure(font)
 
     expected = (datadir / "MutatorSansBoldCondensed.json").read_text()
 
@@ -698,4 +698,4 @@ def test_json_loads(datadir: pathlib.Path) -> None:
     # opening the UFO on Windows
     expected.features.normalize_newlines()
 
-    assert default_converter.structure(data, Font) == expected
+    assert structure(data, Font) == expected


### PR DESCRIPTION
Instead of exposing a `ufoLib2.converters.default_converter` and call `unstructure` and `structure` methods on it, I like it better to define two global `structure` and `unstructure` functions (which are actually bound methods of the default converter re-exported as standalone functions), similarly to how one does`from cattr import structure, unstructure`.
E.g.: instead of `from ufoLib2.converters import default_converter as conv; conv.structure(..., Font)`, you now do

```python
import orjson
from ufoLib2.objects import Font
from ufoLib2.converters import structure, unstructure

with open("MyFont.json", "rb") as f:
    json_data = orjson.loads(f.read())
font = structure(json_data, Font)
...
json_data = orjson.dumps(unstructure(font), option=orjson.OPT_INDENT_2 | orjson.OPT_SORT_KEYS)
with open("MyFont2.json", "wb") as f:
    f.write(json_data)
```