### PR TITLE
add tempLib to Font, Layer and Glyph (like defcon's)

### DIFF
--- a/src/ufoLib2/objects/font.py
+++ b/src/ufoLib2/objects/font.py
@@ -31,7 +31,14 @@ from ufoLib2.objects.info import Info
 from ufoLib2.objects.kerning import Kerning, KerningPair
 from ufoLib2.objects.layer import Layer
 from ufoLib2.objects.layerSet import LayerSet
-from ufoLib2.objects.lib import Lib, _convert_Lib, _get_lib, _set_lib
+from ufoLib2.objects.lib import (
+    Lib,
+    _convert_Lib,
+    _get_lib,
+    _get_tempLib,
+    _set_lib,
+    _set_tempLib,
+)
 from ufoLib2.objects.misc import (
     BoundingBox,
     _deepcopy_unlazify_attrs,
@@ -100,6 +107,8 @@ class Font:
         lib (Dict[str, Any]): A mapping of keys to arbitrary values.
         data (DataSet): A mapping of data file paths to arbitrary data.
         images (ImageSet): A mapping of image file paths to arbitrary image data.
+        tempLib (Dict[str, Any]): A temporary mapping of keys to arbitrary values
+            which unlike lib are *not* saved to disk.
 
     Behavior:
         The Font object has some dict-like behavior for quick access to glyphs on the
@@ -165,6 +174,9 @@ class Font:
 
     images: ImageSet = field(factory=ImageSet, converter=_convert_ImageSet)
     """ImageSet: A mapping of image file paths to arbitrary image data."""
+
+    _tempLib: Lib = field(factory=Lib, converter=_convert_Lib)
+    """Dict[str, PlistEncodable]: A temporary map of arbitrary plist values."""
 
     # init=False args, set by alternate open/read classmethod constructors
     _path: Optional[PathLike] = field(default=None, eq=False, init=False)
@@ -375,6 +387,8 @@ class Font:
     kerning = property(_get_kerning, _set_kerning)
 
     lib = property(_get_lib, _set_lib)
+
+    tempLib = property(_get_tempLib, _set_tempLib)
 
     def objectLib(self, object: HasIdentifier) -> dict[str, Any]:
         """Return the lib for an object with an identifier, as stored in a font's lib.

--- a/src/ufoLib2/objects/glyph.py
+++ b/src/ufoLib2/objects/glyph.py
@@ -17,7 +17,14 @@ from ufoLib2.objects.component import Component
 from ufoLib2.objects.contour import Contour
 from ufoLib2.objects.guideline import Guideline
 from ufoLib2.objects.image import Image
-from ufoLib2.objects.lib import Lib, _convert_Lib, _get_lib, _set_lib
+from ufoLib2.objects.lib import (
+    Lib,
+    _convert_Lib,
+    _get_lib,
+    _get_tempLib,
+    _set_lib,
+    _set_tempLib,
+)
 from ufoLib2.objects.misc import BoundingBox, _object_lib, getBounds, getControlBounds
 from ufoLib2.pointPens.glyphPointPen import GlyphPointPen
 from ufoLib2.serde import serde
@@ -84,6 +91,9 @@ class Glyph:
 
     _guidelines: List[Guideline] = field(factory=list)
 
+    _tempLib: Lib = field(factory=Lib, converter=_convert_Lib)
+    """A temporary map of arbitrary plist values."""
+
     def __len__(self) -> int:
         return len(self.contours)
 
@@ -105,6 +115,8 @@ class Glyph:
         )
 
     lib = property(_get_lib, _set_lib)
+
+    tempLib = property(_get_tempLib, _set_tempLib)
 
     @property
     def anchors(self) -> list[Anchor]:

--- a/src/ufoLib2/objects/layer.py
+++ b/src/ufoLib2/objects/layer.py
@@ -17,7 +17,14 @@ from fontTools.ufoLib.glifLib import GlyphSet
 
 from ufoLib2.constants import DEFAULT_LAYER_NAME
 from ufoLib2.objects.glyph import Glyph
-from ufoLib2.objects.lib import Lib, _convert_Lib, _get_lib, _set_lib
+from ufoLib2.objects.lib import (
+    Lib,
+    _convert_Lib,
+    _get_lib,
+    _get_tempLib,
+    _set_lib,
+    _set_tempLib,
+)
 from ufoLib2.objects.misc import (
     BoundingBox,
     _deepcopy_unlazify_attrs,
@@ -118,6 +125,9 @@ class Layer:
     """Can set to True to mark a layer as default. If layer name is 'public.default'
     the default attribute is automatically True. Exactly one layer must be marked as
     default in a font."""
+
+    _tempLib: Lib = field(factory=Lib, converter=_convert_Lib)
+    """A temporary map of arbitrary plist values."""
 
     _lazy: Optional[bool] = field(default=None, init=False, eq=False)
     _glyphSet: Any = field(default=None, init=False, eq=False)
@@ -249,6 +259,8 @@ class Layer:
         return self._name
 
     lib = property(_get_lib, _set_lib)
+
+    tempLib = property(_get_tempLib, _set_tempLib)
 
     @property
     def default(self) -> bool:
@@ -399,6 +411,7 @@ class Layer:
             ("default", self._default, self._name == DEFAULT_LAYER_NAME),
             ("glyphs", glyphs, {}),
             ("lib", self._lib, {}),
+            ("tempLib", self._tempLib, {}),
         ]:
             if not converter.omit_if_default or value != default:
                 d[key] = value
@@ -419,6 +432,7 @@ class Layer:
             color=data.get("color"),
             lib=converter.structure(data.get("lib", {}), Lib),
             default=data.get("default", False),
+            tempLib=converter.structure(data.get("tempLib", {}), Lib),
         )
 
 

--- a/src/ufoLib2/objects/lib.py
+++ b/src/ufoLib2/objects/lib.py
@@ -36,6 +36,14 @@ def _set_lib(self: Any, value: Mapping[str, Any]) -> None:
     self._lib = _convert_Lib(value)
 
 
+def _get_tempLib(self: Any) -> Lib:
+    return cast(Lib, self._tempLib)
+
+
+def _set_tempLib(self: Any, value: Mapping[str, Any]) -> None:
+    self._tempLib = _convert_Lib(value)
+
+
 def is_data_dict(value: Any) -> bool:
     return (
         isinstance(value, Mapping)

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -471,7 +471,12 @@ from ufoLib2.converters import register_hooks, structure, unstructure  # noqa: E
         ),
         (
             Font(
-                layers=[Layer(glyphs=[Glyph("a")])],
+                layers=[
+                    Layer(
+                        glyphs=[Glyph("a", tempLib={"foo": "bar"})],
+                        tempLib={"a": 123},
+                    )
+                ],
                 info=Info(familyName="Test"),
                 features="languagesystem DFLT dflt;",
                 groups={"LOWERCASE": ["a"]},
@@ -479,12 +484,14 @@ from ufoLib2.converters import register_hooks, structure, unstructure  # noqa: E
                 lib={"foo": "bar"},
                 data={"baz": b"\0"},
                 images={"foobarbaz": b"\0"},
+                tempLib={"foofoo": "barbar"},
             ),
             {
                 "layers": [
                     {
                         "name": "public.default",
-                        "glyphs": {"a": {}},
+                        "glyphs": {"a": {"tempLib": {"foo": "bar"}}},
+                        "tempLib": {"a": 123},
                     }
                 ],
                 "info": {"familyName": "Test"},
@@ -494,6 +501,7 @@ from ufoLib2.converters import register_hooks, structure, unstructure  # noqa: E
                 "lib": {"foo": "bar"},
                 "data": {"baz": "AA=="},
                 "images": {"foobarbaz": "AA=="},
+                "tempLib": {"foofoo": "barbar"},
             },
         ),
     ],
@@ -572,6 +580,7 @@ def test_structure_forbid_extra_keys(forbid_extra_keys: bool) -> None:
                 "components": [],
                 "contours": [],
                 "guidelines": [],
+                "tempLib": {},
             },
             id="False-Glyph",
         ),
@@ -579,7 +588,13 @@ def test_structure_forbid_extra_keys(forbid_extra_keys: bool) -> None:
         pytest.param(
             False,
             Layer(),
-            {"name": "public.default", "default": True, "glyphs": {}, "lib": {}},
+            {
+                "name": "public.default",
+                "default": True,
+                "glyphs": {},
+                "lib": {},
+                "tempLib": {},
+            },
             id="False-Layer",
         ),
         pytest.param(
@@ -596,9 +611,16 @@ def test_structure_forbid_extra_keys(forbid_extra_keys: bool) -> None:
                 "info": {},
                 "kerning": {},
                 "layers": [
-                    {"default": True, "glyphs": {}, "lib": {}, "name": "public.default"}
+                    {
+                        "default": True,
+                        "glyphs": {},
+                        "lib": {},
+                        "name": "public.default",
+                        "tempLib": {},
+                    }
                 ],
                 "lib": {},
+                "tempLib": {},
             },
             id="False-Font",
         ),
@@ -680,6 +702,7 @@ def test_custom_type_overrides() -> None:
         "components": [],
         "contours": [],
         "guidelines": [],
+        "tempLib": {},
     }
 
 


### PR DESCRIPTION
This adds the equivalent of defcon's tempLib to the Font, Layer and Glyph objects. It's a temporary 'lib' that does not get saved to disk. Can be useful at times (I need this in fontmake right now).

https://github.com/robotools/defcon/pull/367