### PR TITLE
[glyph] Add outputImpliedClosingLine to draw()

### DIFF
--- a/src/ufoLib2/objects/glyph.py
+++ b/src/ufoLib2/objects/glyph.py
@@ -355,10 +355,12 @@ class Glyph:
     # Pen methods
     # -----------
 
-    def draw(self, pen: AbstractPen) -> None:
+    def draw(self, pen: AbstractPen, outputImpliedClosingLine: bool = False) -> None:
         """Draws glyph into given pen."""
         # TODO: Document pen interface more or link to somewhere.
-        pointPen = PointToSegmentPen(pen)
+        pointPen = PointToSegmentPen(
+            pen, outputImpliedClosingLine=outputImpliedClosingLine
+        )
         self.drawPoints(pointPen)
 
     def drawPoints(self, pointPen: AbstractPointPen) -> None:


### PR DESCRIPTION
This is in line with what `ufoLib` does.

Fixes https://github.com/fonttools/fonttools/issues/3694