### PR TITLE
define own structuring hook for fontTools Transform

### DIFF
--- a/src/ufoLib2/converters.py
+++ b/src/ufoLib2/converters.py
@@ -98,6 +98,9 @@ def register_hooks(conv: Converter, allow_bytes: bool = True) -> None:
     def unstructure_transform(t: Transform) -> Tuple[float]:
         return cast(Tuple[float], tuple(t))
 
+    def structure_transform(t: Tuple[float], _: Any) -> Transform:
+        return Transform(*t)
+
     conv.register_unstructure_hook_factory(
         is_ufoLib2_attrs_class,
         partial(attrs_hook_factory, gen_fn=make_dict_unstructure_fn, structuring=False),
@@ -110,6 +113,7 @@ def register_hooks(conv: Converter, allow_bytes: bool = True) -> None:
         cast(Type[Transform], Transform), unstructure_transform
     )
 
+    conv.register_structure_hook(cast(Type[Transform], Transform), structure_transform)
     conv.register_structure_hook_factory(
         is_ufoLib2_attrs_class,
         partial(attrs_hook_factory, gen_fn=make_dict_structure_fn, structuring=True),


### PR DESCRIPTION
Fixes https://github.com/fonttools/fonttools/issues/3744

cattrs built-in structuring hook for namedtuples (like fontTools' Transform) fails when using `from __future__ import annotations`, we can avoid it by defining our own structuring hook specific to Transform class, which is trivial