### PR TITLE
Fix typo in width class label

### DIFF
--- a/src/ufoLib2/objects/info/__init__.py
+++ b/src/ufoLib2/objects/info/__init__.py
@@ -93,7 +93,7 @@ class NameRecord(AttrDictMixin):
 
 class WidthClass(IntEnum):
     ULTRA_CONDENSED = 1
-    EXTRA_CONDESED = 2
+    EXTRA_CONDENSED = 2
     CONDENSED = 3
     SEMI_CONDENSED = 4
     NORMAL = 5  # alias for WidthClass.MEDIUM


### PR DESCRIPTION
This snuck through for a while! Not causing any problems, but noticed when debugging and thought it deserved a fix.

[A GitHub-wide search of the constant's name only shows this repository and forks thereof](https://github.com/search?q=%22EXTRA_CONDESED%22&type=code), and so we can be reasonably confident that this won't cause problems downstream.