### PR TITLE
Ignore temporary directory cleanup errors

### DIFF
--- a/src/ufoLib2/objects/font.py
+++ b/src/ufoLib2/objects/font.py
@@ -610,7 +610,10 @@ class Font:
         finally:
             # clean up the temporary directory
             if tmp is not None:
-                tmp.cleanup()
+                try:
+                    tmp.cleanup()
+                except PermissionError:
+                    pass
 
         # Only remember path if it isn't a fs.base.FS because not all FS objects are
         # OsFS with a corresponding filesystem path. E.g. think about MemoryFS.

--- a/src/ufoLib2/objects/font.py
+++ b/src/ufoLib2/objects/font.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import sys
 import tempfile
 from typing import (
     Any,
@@ -575,7 +576,10 @@ class Font:
             if isinstance(path, str) and os.path.exists(path):
                 if overwrite:
                     overwritePath = path
-                    tmp = tempfile.TemporaryDirectory()
+                    if sys.version_info < (3, 10):
+                        tmp = tempfile.TemporaryDirectory()
+                    else:
+                        tmp = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
                     path = os.path.join(tmp.name, os.path.basename(path))
                 else:
                     import errno


### PR DESCRIPTION
Follow-up to #393.

Sadly only available in Python >= 3.10, but oh well.