### PR TITLE
Use trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,11 +94,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - name: Install dependencies
-        run: |
-          pip install build twine
-      - name: Build and publish
-        run: |
-          python -m build
-          twine check dist/*
-          twine upload dist/*
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v6
+      - name: Build
+        run: uv build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.13.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,11 @@ jobs:
       - docs
       - test
     runs-on: ubuntu-latest
+    environment:
+      name: publish-to-pypi
+      url: https://pypi.org/p/ufoLib2
+    permissions:
+      id-token: write # IMPORTANT: mandatory for trusted publishing.
 
     steps:
       - uses: actions/checkout@v4
@@ -93,9 +98,6 @@ jobs:
         run: |
           pip install build twine
       - name: Build and publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           python -m build
           twine check dist/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,9 +94,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v6
       - name: Build
-        run: uv build
+        run: pipx run build
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@v1.13.0


### PR DESCRIPTION
In light of the recent npm supply chain attacks and also https://blog.pypi.org/posts/2025-09-16-github-actions-token-exfiltration/, I'm combing through our font stack to see if all them Py projects are using the trusted publisher mechanism as recommended by PyPI. See https://docs.pypi.org/trusted-publishers/ and https://docs.astral.sh/uv/guides/integration/github/#publishing-to-pypi.

Someone needs to do three things for this PR to work:

* Create an environment called "publish-to-pypi" in this GitHub repository under Settings -> Environments. Creating alone is probably enough, no configuration needed I think.
* Follow https://docs.pypi.org/trusted-publishers/adding-a-publisher/ to set up the other side on PyPI.
* Remove tokens/secret variables here so they can't be exfiltrated anymore, and probably also remove them from PyPI.

I'm not sure if one needs to do anything to make twine pick up the new creds, trusted publishing should be supported in v6.1.0.