### PR TITLE
Refactor type hints and clean up code

### DIFF
--- a/docs/source/explanations.rst
+++ b/docs/source/explanations.rst
@@ -69,7 +69,7 @@ changes, but complicates adding libs to the objects directly. Since ufoLib2
 intentionally lacks defcon's parent-child object hierarchy, a guideline can't
 follow a link to the containing parent and access its lib. Magically loading
 and storing the ``public.objectLibs`` lib key on loading and saving a UFO adds
-an uncomfortable amount of magic and edge-casiness. What if a client itself
+an uncomfortable amount of magic and edge-cases. What if a client itself
 adds a ``public.objectLibs`` entry for an object that differs from what is in
 that object's lib? Overwrite, ignore, error out? With the ``.objectLib``
 method, this edge case does not exist.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ multi_line_output = 3
 profile = "black"
 float_to_top = true
 known_first_party = "ufoLib2"
+split_on_trailing_comma = false
 
 [tool.mypy]
 python_version = "3.10"

--- a/src/ufoLib2/constants.py
+++ b/src/ufoLib2/constants.py
@@ -12,7 +12,7 @@ See:
 - https://unifiedfontobject.org/versions/ufo3/glyphs/glif/#publicobjectlibs
 """
 
-DATA_LIB_KEY = "com.github.fonttools.ufoLib2.lib.plist.data"
+DATA_LIB_KEY: str = "com.github.fonttools.ufoLib2.lib.plist.data"
 """
 Lib key used for serializing binary data as JSON-encodable string.
 """

--- a/src/ufoLib2/converters.py
+++ b/src/ufoLib2/converters.py
@@ -63,7 +63,7 @@ def register_hooks(conv: Converter, allow_bytes: bool = True) -> None:
             else:
                 # by default, we omit all Optional attributes (i.e. with None default),
                 # overriding a Converter's global 'omit_if_default' option. Specific
-                # attibutes can still define their own 'omit_if_default' behavior in
+                # attributes can still define their own 'omit_if_default' behavior in
                 # the Attribute.metadata dict.
                 attrib_override = override(
                     omit_if_default=a.metadata.get(

--- a/src/ufoLib2/converters.py
+++ b/src/ufoLib2/converters.py
@@ -1,25 +1,14 @@
 from __future__ import annotations
 
-import sys
+from collections.abc import Callable
 from functools import partial
-from typing import Any, Callable, Tuple, Type, cast
+from typing import Any, cast, get_origin
 
 from attrs import fields, has, resolve_types
 from cattrs import Converter
 from cattrs.gen import make_dict_structure_fn, make_dict_unstructure_fn, override
 from cattrs.gen._consts import AttributeOverride
 from fontTools.misc.transform import Transform
-
-is_py37 = sys.version_info[:2] == (3, 7)
-
-if is_py37:
-
-    def get_origin(cl: Type[Any]) -> Any:
-        return getattr(cl, "__origin__", None)
-
-else:
-    from typing import get_origin  # type: ignore
-
 
 __all__ = [
     "register_hooks",
@@ -28,26 +17,26 @@ __all__ = [
 ]
 
 
-def is_ufoLib2_class(cls: Type[Any]) -> bool:
+def is_ufoLib2_class(cls: type[Any]) -> bool:
     mod: str = getattr(cls, "__module__", "")
     return mod.split(".")[0] == "ufoLib2"
 
 
-def is_ufoLib2_attrs_class(cls: Type[Any]) -> bool:
-    return is_ufoLib2_class(cls) and (has(cls) or has(get_origin(cls)))
+def is_ufoLib2_attrs_class(cls: type[Any]) -> bool:
+    return is_ufoLib2_class(cls) and (has(cls) or has(get_origin(cls)))  # type: ignore
 
 
-def is_ufoLib2_class_with_custom_unstructure(cls: Type[Any]) -> bool:
+def is_ufoLib2_class_with_custom_unstructure(cls: type[Any]) -> bool:
     return is_ufoLib2_class(cls) and hasattr(cls, "_unstructure")
 
 
-def is_ufoLib2_class_with_custom_structure(cls: Type[Any]) -> bool:
+def is_ufoLib2_class_with_custom_structure(cls: type[Any]) -> bool:
     return is_ufoLib2_class(cls) and hasattr(cls, "_structure")
 
 
 def register_hooks(conv: Converter, allow_bytes: bool = True) -> None:
     def attrs_hook_factory(
-        cls: Type[Any], gen_fn: Callable[..., Callable[..., Any]], structuring: bool
+        cls: type[Any], gen_fn: Callable[..., Callable[..., Any]], structuring: bool
     ) -> Callable[..., Any]:
         base = get_origin(cls)
         if base is None:
@@ -89,16 +78,16 @@ def register_hooks(conv: Converter, allow_bytes: bool = True) -> None:
 
         return gen_fn(cls, conv, **kwargs)
 
-    def custom_unstructure_hook_factory(cls: Type[Any]) -> Callable[[Any], Any]:
+    def custom_unstructure_hook_factory(cls: type[Any]) -> Callable[[Any], Any]:
         return partial(cls._unstructure, converter=conv)
 
-    def custom_structure_hook_factory(cls: Type[Any]) -> Callable[[Any, Any], Any]:
+    def custom_structure_hook_factory(cls: type[Any]) -> Callable[[Any, Any], Any]:
         return partial(cls._structure, converter=conv)
 
-    def unstructure_transform(t: Transform) -> Tuple[float]:
-        return cast(Tuple[float], tuple(t))
+    def unstructure_transform(t: Transform) -> tuple[float]:
+        return cast(tuple[float], tuple(t))
 
-    def structure_transform(t: Tuple[float], _: Any) -> Transform:
+    def structure_transform(t: tuple[float], _: Any) -> Transform:
         return Transform(*t)
 
     conv.register_unstructure_hook_factory(
@@ -109,11 +98,9 @@ def register_hooks(conv: Converter, allow_bytes: bool = True) -> None:
         is_ufoLib2_class_with_custom_unstructure,
         custom_unstructure_hook_factory,
     )
-    conv.register_unstructure_hook(
-        cast(Type[Transform], Transform), unstructure_transform
-    )
+    conv.register_unstructure_hook(Transform, unstructure_transform)
 
-    conv.register_structure_hook(cast(Type[Transform], Transform), structure_transform)
+    conv.register_structure_hook(Transform, structure_transform)
     conv.register_structure_hook_factory(
         is_ufoLib2_attrs_class,
         partial(attrs_hook_factory, gen_fn=make_dict_structure_fn, structuring=True),

--- a/src/ufoLib2/objects/anchor.py
+++ b/src/ufoLib2/objects/anchor.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from attrs import define
 
 from ufoLib2.objects.misc import AttrDictMixin
@@ -22,13 +20,13 @@ class Anchor(AttrDictMixin):
     y: float
     """The y coordinate of the anchor."""
 
-    name: Optional[str] = None
+    name: str | None = None
     """The name of the anchor."""
 
-    color: Optional[str] = None
+    color: str | None = None
     """The color of the anchor."""
 
-    identifier: Optional[str] = None
+    identifier: str | None = None
     """The globally unique identifier of the anchor."""
 
     def move(self, delta: tuple[float, float]) -> None:

--- a/src/ufoLib2/objects/component.py
+++ b/src/ufoLib2/objects/component.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import warnings
-from typing import Optional
 
 from attrs import define, field
 from fontTools.misc.transform import Identity, Transform
@@ -33,7 +32,7 @@ class Component:
     transformation: Transform = field(default=Identity, converter=_convert_transform)
     """The affine transformation to apply to the :attr:`.Component.baseGlyph`."""
 
-    identifier: Optional[str] = None
+    identifier: str | None = None
     """The globally unique identifier of the component."""
 
     def move(self, delta: tuple[float, float]) -> None:

--- a/src/ufoLib2/objects/contour.py
+++ b/src/ufoLib2/objects/contour.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import warnings
-from typing import Iterable, Iterator, List, MutableSequence, Optional, overload
+from collections.abc import Iterable, Iterator, MutableSequence
+from typing import overload
 
 from attrs import define, field
 from fontTools.pens.basePen import AbstractPen
@@ -42,10 +43,10 @@ class Contour(MutableSequence[Point]):
             contour[0] = anotherPoint
     """
 
-    points: List[Point] = field(factory=list)
+    points: list[Point] = field(factory=list)
     """The list of points in the contour."""
 
-    identifier: Optional[str] = field(default=None, repr=False)
+    identifier: str | None = field(default=None, repr=False)
     """The globally unique identifier of the contour."""
 
     # collections.abc.MutableSequence interface

--- a/src/ufoLib2/objects/dataSet.py
+++ b/src/ufoLib2/objects/dataSet.py
@@ -10,7 +10,7 @@ from ufoLib2.serde import serde
 class DataSet(DataStore):
     """Represents a mapping of POSIX filename strings to arbitrary data bytes.
 
-    Always use forward slahes (/) as directory separators, even on Windows.
+    Always use forward slashes (/) as directory separators, even on Windows.
 
     Behavior:
         DataSet behaves like a dictionary of type ``Dict[str, bytes]``.

--- a/src/ufoLib2/objects/features.py
+++ b/src/ufoLib2/objects/features.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Type
+from typing import TYPE_CHECKING
 
 from attrs import define
 
@@ -41,6 +41,6 @@ class Features:
         return self.text
 
     @staticmethod
-    def _structure(data: str, cls: Type[Features], converter: Converter) -> Features:
+    def _structure(data: str, cls: type[Features], converter: Converter) -> Features:
         del converter  # unused
         return cls(data)

--- a/src/ufoLib2/objects/font.py
+++ b/src/ufoLib2/objects/font.py
@@ -2,19 +2,17 @@ from __future__ import annotations
 
 import os
 import shutil
-import sys
 import tempfile
-from typing import (
-    Any,
-    Dict,
+from collections.abc import (
     Iterable,
     Iterator,
     KeysView,
-    List,
     Mapping,
     MutableMapping,
-    Optional,
     Sequence,
+)
+from typing import (
+    Any,
     cast,
 )
 
@@ -159,7 +157,7 @@ class Font:
     features: Features = field(factory=Features, converter=_convert_Features)
     """Features: The font Features object."""
 
-    groups: Dict[str, List[str]] = field(factory=dict)
+    groups: dict[str, list[str]] = field(factory=dict)
     """Dict[str, List[str]]: A mapping of group names to a list of glyph names."""
 
     _kerning: Kerning = field(factory=Kerning, converter=_convert_Kerning)
@@ -179,12 +177,10 @@ class Font:
     """Dict[str, PlistEncodable]: A temporary map of arbitrary plist values."""
 
     # init=False args, set by alternate open/read classmethod constructors
-    _path: Optional[PathLike] = field(default=None, eq=False, init=False)
-    _lazy: Optional[bool] = field(default=None, init=False, eq=False)
-    _reader: Optional[UFOReader] = field(default=None, init=False, eq=False)
-    _fileStructure: Optional[UFOFileStructure] = field(
-        default=None, init=False, eq=False
-    )
+    _path: PathLike | None = field(default=None, eq=False, init=False)
+    _lazy: bool | None = field(default=None, init=False, eq=False)
+    _reader: UFOReader | None = field(default=None, init=False, eq=False)
+    _fileStructure: UFOFileStructure | None = field(default=None, init=False, eq=False)
 
     @classmethod
     def open(cls, path: PathLike, lazy: bool = True, validate: bool = True) -> Font:
@@ -576,10 +572,7 @@ class Font:
             if isinstance(path, str) and os.path.exists(path):
                 if overwrite:
                     overwritePath = path
-                    if sys.version_info < (3, 10):
-                        tmp = tempfile.TemporaryDirectory()
-                    else:
-                        tmp = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+                    tmp = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
                     path = os.path.join(tmp.name, os.path.basename(path))
                 else:
                     import errno

--- a/src/ufoLib2/objects/font.py
+++ b/src/ufoLib2/objects/font.py
@@ -157,7 +157,7 @@ class Font:
     features: Features = field(factory=Features, converter=_convert_Features)
     """Features: The font Features object."""
 
-    groups: dict[str, list[str]] = field(factory=dict)
+    groups: dict[str, list[str]] = field(factory=dict[str, list[str]])
     """Dict[str, List[str]]: A mapping of group names to a list of glyph names."""
 
     _kerning: Kerning = field(factory=Kerning, converter=_convert_Kerning)

--- a/src/ufoLib2/objects/font.py
+++ b/src/ufoLib2/objects/font.py
@@ -11,10 +11,7 @@ from collections.abc import (
     MutableMapping,
     Sequence,
 )
-from typing import (
-    Any,
-    cast,
-)
+from typing import Any, cast
 
 from attrs import define, field
 from fontTools.ufoLib import UFOFileStructure, UFOReader, UFOWriter

--- a/src/ufoLib2/objects/glyph.py
+++ b/src/ufoLib2/objects/glyph.py
@@ -71,7 +71,7 @@ class Glyph:
     height: float = 0
     """The height of the glyph."""
 
-    unicodes: list[int] = field(factory=list)
+    unicodes: list[int] = field(factory=list[int])
     """The Unicode code points assigned to the glyph. Note that a glyph can have
     multiple."""
 
@@ -83,14 +83,14 @@ class Glyph:
     note: str | None = None
     """A free form text note about the glyph."""
 
-    _anchors: list[Anchor] = field(factory=list)
-    components: list[Component] = field(factory=list)
+    _anchors: list[Anchor] = field(factory=list[Anchor])
+    components: list[Component] = field(factory=list[Component])
     """The list of components the glyph contains."""
 
-    contours: list[Contour] = field(factory=list)
+    contours: list[Contour] = field(factory=list[Contour])
     """The list of contours the glyph contains."""
 
-    _guidelines: list[Guideline] = field(factory=list)
+    _guidelines: list[Guideline] = field(factory=list[Guideline])
 
     _tempLib: Lib = field(factory=Lib, converter=_convert_Lib)
     """A temporary map of arbitrary plist values."""

--- a/src/ufoLib2/objects/glyph.py
+++ b/src/ufoLib2/objects/glyph.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Iterator, Mapping
 from copy import deepcopy
-from typing import Any, Iterator, List, Mapping, Optional, cast
+from typing import Any, Optional, cast
 
 from attrs import define, field
 from fontTools.misc.transform import Transform
@@ -62,7 +63,7 @@ class Glyph:
         :attr:`.Glyph.components` and :attr:`.Glyph.anchors` attributes.
     """
 
-    _name: Optional[str] = None
+    _name: str | None = None
 
     width: float = 0
     """The width of the glyph."""
@@ -70,7 +71,7 @@ class Glyph:
     height: float = 0
     """The height of the glyph."""
 
-    unicodes: List[int] = field(factory=list)
+    unicodes: list[int] = field(factory=list)
     """The Unicode code points assigned to the glyph. Note that a glyph can have
     multiple."""
 
@@ -79,17 +80,17 @@ class Glyph:
     _lib: Lib = field(factory=Lib, converter=_convert_Lib)
     """The glyph's mapping of string keys to arbitrary data."""
 
-    note: Optional[str] = None
+    note: str | None = None
     """A free form text note about the glyph."""
 
-    _anchors: List[Anchor] = field(factory=list)
-    components: List[Component] = field(factory=list)
+    _anchors: list[Anchor] = field(factory=list)
+    components: list[Component] = field(factory=list)
     """The list of components the glyph contains."""
 
-    contours: List[Contour] = field(factory=list)
+    contours: list[Contour] = field(factory=list)
     """The list of contours the glyph contains."""
 
-    _guidelines: List[Guideline] = field(factory=list)
+    _guidelines: list[Guideline] = field(factory=list)
 
     _tempLib: Lib = field(factory=Lib, converter=_convert_Lib)
     """A temporary map of arbitrary plist values."""

--- a/src/ufoLib2/objects/guideline.py
+++ b/src/ufoLib2/objects/guideline.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from attrs import define
 
 from ufoLib2.objects.misc import AttrDictMixin
@@ -17,22 +15,22 @@ class Guideline(AttrDictMixin):
     data composition restrictions.
     """
 
-    x: Optional[float] = None
+    x: float | None = None
     """The origin x coordinate of the guideline."""
 
-    y: Optional[float] = None
+    y: float | None = None
     """The origin y coordinate of the guideline."""
 
-    angle: Optional[float] = None
+    angle: float | None = None
     """The angle of the guideline."""
 
-    name: Optional[str] = None
+    name: str | None = None
     """The name of the guideline, no uniqueness required."""
 
-    color: Optional[str] = None
+    color: str | None = None
     """The color of the guideline."""
 
-    identifier: Optional[str] = None
+    identifier: str | None = None
     """The globally unique identifier of the guideline."""
 
     def __attrs_post_init__(self) -> None:

--- a/src/ufoLib2/objects/image.py
+++ b/src/ufoLib2/objects/image.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, ClassVar, Iterator, Mapping, Optional, Tuple
+from collections.abc import Iterator, Mapping
+from typing import Any, ClassVar
 
 from attrs import define, field
 from fontTools.misc.transform import Identity, Transform
@@ -19,13 +20,13 @@ class Image(Mapping[str, Any]):
     http://unifiedfontobject.org/versions/ufo3/glyphs/glif/#image.
     """
 
-    fileName: Optional[str] = None
+    fileName: str | None = None
     """The filename of the image."""
 
     transformation: Transform = field(default=Identity, converter=_convert_transform)
     """The affine transformation applied to the image."""
 
-    color: Optional[str] = None
+    color: str | None = None
     """The color applied to the image."""
 
     def clear(self) -> None:
@@ -42,7 +43,7 @@ class Image(Mapping[str, Any]):
     # the fontTools.ufoLib.validators.imageValidator requires that image is a
     # subclass of Mapping...
 
-    _transformation_keys_: ClassVar[Tuple[str, str, str, str, str, str]] = (
+    _transformation_keys_: ClassVar[tuple[str, str, str, str, str, str]] = (
         "xScale",
         "xyScale",
         "yxScale",
@@ -50,7 +51,7 @@ class Image(Mapping[str, Any]):
         "xOffset",
         "yOffset",
     )
-    _valid_keys_: ClassVar[Tuple[str, str, str, str, str, str, str, str]] = (
+    _valid_keys_: ClassVar[tuple[str, str, str, str, str, str, str, str]] = (
         "fileName",
         *_transformation_keys_,
         "color",

--- a/src/ufoLib2/objects/info/__init__.py
+++ b/src/ufoLib2/objects/info/__init__.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Callable, Mapping, Sequence
 from enum import IntEnum
 from functools import partial
-from typing import Any, Callable, List, Mapping, Optional, Sequence, TypeVar
+from typing import Any, TypeVar
 
 import attrs
 from attrs import define, field
@@ -79,7 +80,7 @@ def _convert_GaspBehavior(seq: Sequence[GaspBehavior | int]) -> list[GaspBehavio
 class GaspRangeRecord(AttrDictMixin):
     rangeMaxPPEM: int = field(validator=_positive)
     # Use Set[GaspBehavior] instead of List?
-    rangeGaspBehavior: List[GaspBehavior] = field(converter=_convert_GaspBehavior)
+    rangeGaspBehavior: list[GaspBehavior] = field(converter=_convert_GaspBehavior)
 
 
 @define
@@ -181,26 +182,26 @@ class Info:
     mostly done during saving and loading.
     """
 
-    familyName: Optional[str] = None
-    styleName: Optional[str] = None
-    styleMapFamilyName: Optional[str] = None
-    styleMapStyleName: Optional[str] = None
-    versionMajor: Optional[int] = field(default=None, validator=_optional_positive)
-    versionMinor: Optional[int] = field(default=None, validator=_optional_positive)
+    familyName: str | None = None
+    styleName: str | None = None
+    styleMapFamilyName: str | None = None
+    styleMapStyleName: str | None = None
+    versionMajor: int | None = field(default=None, validator=_optional_positive)
+    versionMinor: int | None = field(default=None, validator=_optional_positive)
 
-    copyright: Optional[str] = None
-    trademark: Optional[str] = None
+    copyright: str | None = None
+    trademark: str | None = None
 
-    unitsPerEm: Optional[float] = field(default=None, validator=_optional_positive)
-    descender: Optional[float] = None
-    xHeight: Optional[float] = None
-    capHeight: Optional[float] = None
-    ascender: Optional[float] = None
-    italicAngle: Optional[float] = None
+    unitsPerEm: float | None = field(default=None, validator=_optional_positive)
+    descender: float | None = None
+    xHeight: float | None = None
+    capHeight: float | None = None
+    ascender: float | None = None
+    italicAngle: float | None = None
 
-    note: Optional[str] = None
+    note: str | None = None
 
-    _guidelines: Optional[List[Guideline]] = field(
+    _guidelines: list[Guideline] | None = field(
         default=None, converter=_convert_guidelines
     )
 
@@ -212,7 +213,7 @@ class Info:
     def guidelines(self, value: list[Guideline] | None) -> None:
         self._guidelines = _convert_guidelines(value)
 
-    _openTypeGaspRangeRecords: Optional[List[GaspRangeRecord]] = field(
+    _openTypeGaspRangeRecords: list[GaspRangeRecord] | None = field(
         default=None, converter=_convert_gasp_range_records
     )
 
@@ -224,36 +225,36 @@ class Info:
     def openTypeGaspRangeRecords(self, value: list[GaspRangeRecord] | None) -> None:
         self._openTypeGaspRangeRecords = _convert_gasp_range_records(value)
 
-    openTypeHeadCreated: Optional[str] = None
-    openTypeHeadLowestRecPPEM: Optional[int] = field(
+    openTypeHeadCreated: str | None = None
+    openTypeHeadLowestRecPPEM: int | None = field(
         default=None, validator=_optional_positive
     )
-    openTypeHeadFlags: Optional[List[int]] = None
+    openTypeHeadFlags: list[int] | None = None
 
-    openTypeHheaAscender: Optional[int] = None
-    openTypeHheaDescender: Optional[int] = None
-    openTypeHheaLineGap: Optional[int] = None
-    openTypeHheaCaretSlopeRise: Optional[int] = None
-    openTypeHheaCaretSlopeRun: Optional[int] = None
-    openTypeHheaCaretOffset: Optional[int] = None
+    openTypeHheaAscender: int | None = None
+    openTypeHheaDescender: int | None = None
+    openTypeHheaLineGap: int | None = None
+    openTypeHheaCaretSlopeRise: int | None = None
+    openTypeHheaCaretSlopeRun: int | None = None
+    openTypeHheaCaretOffset: int | None = None
 
-    openTypeNameDesigner: Optional[str] = None
-    openTypeNameDesignerURL: Optional[str] = None
-    openTypeNameManufacturer: Optional[str] = None
-    openTypeNameManufacturerURL: Optional[str] = None
-    openTypeNameLicense: Optional[str] = None
-    openTypeNameLicenseURL: Optional[str] = None
-    openTypeNameVersion: Optional[str] = None
-    openTypeNameUniqueID: Optional[str] = None
-    openTypeNameDescription: Optional[str] = None
-    openTypeNamePreferredFamilyName: Optional[str] = None
-    openTypeNamePreferredSubfamilyName: Optional[str] = None
-    openTypeNameCompatibleFullName: Optional[str] = None
-    openTypeNameSampleText: Optional[str] = None
-    openTypeNameWWSFamilyName: Optional[str] = None
-    openTypeNameWWSSubfamilyName: Optional[str] = None
+    openTypeNameDesigner: str | None = None
+    openTypeNameDesignerURL: str | None = None
+    openTypeNameManufacturer: str | None = None
+    openTypeNameManufacturerURL: str | None = None
+    openTypeNameLicense: str | None = None
+    openTypeNameLicenseURL: str | None = None
+    openTypeNameVersion: str | None = None
+    openTypeNameUniqueID: str | None = None
+    openTypeNameDescription: str | None = None
+    openTypeNamePreferredFamilyName: str | None = None
+    openTypeNamePreferredSubfamilyName: str | None = None
+    openTypeNameCompatibleFullName: str | None = None
+    openTypeNameSampleText: str | None = None
+    openTypeNameWWSFamilyName: str | None = None
+    openTypeNameWWSSubfamilyName: str | None = None
 
-    _openTypeNameRecords: Optional[List[NameRecord]] = field(
+    _openTypeNameRecords: list[NameRecord] | None = field(
         default=None, converter=_convert_name_records
     )
 
@@ -265,7 +266,7 @@ class Info:
     def openTypeNameRecords(self, value: list[NameRecord] | None) -> None:
         self._openTypeNameRecords = _convert_name_records(value)
 
-    _openTypeOS2WidthClass: Optional[WidthClass] = field(
+    _openTypeOS2WidthClass: WidthClass | None = field(
         default=None, converter=_convert_WidthClass
     )
 
@@ -277,79 +278,77 @@ class Info:
     def openTypeOS2WidthClass(self, value: WidthClass | None) -> None:
         self._openTypeOS2WidthClass = value if value is None else WidthClass(value)
 
-    openTypeOS2WeightClass: Optional[int] = field(default=None)
+    openTypeOS2WeightClass: int | None = field(default=None)
 
     @openTypeOS2WeightClass.validator
     def _validate_weight_class(self, attribute: Any, value: int | None) -> None:
         if value is not None and (value < 1 or value > 1000):
             raise ValueError("'openTypeOS2WeightClass' must be between 1 and 1000")
 
-    openTypeOS2Selection: Optional[List[int]] = None
-    openTypeOS2VendorID: Optional[str] = None
-    openTypeOS2Panose: Optional[List[int]] = None
-    openTypeOS2FamilyClass: Optional[List[int]] = None
-    openTypeOS2UnicodeRanges: Optional[List[int]] = None
-    openTypeOS2CodePageRanges: Optional[List[int]] = None
-    openTypeOS2TypoAscender: Optional[int] = None
-    openTypeOS2TypoDescender: Optional[int] = None
-    openTypeOS2TypoLineGap: Optional[int] = None
-    openTypeOS2WinAscent: Optional[int] = field(
+    openTypeOS2Selection: list[int] | None = None
+    openTypeOS2VendorID: str | None = None
+    openTypeOS2Panose: list[int] | None = None
+    openTypeOS2FamilyClass: list[int] | None = None
+    openTypeOS2UnicodeRanges: list[int] | None = None
+    openTypeOS2CodePageRanges: list[int] | None = None
+    openTypeOS2TypoAscender: int | None = None
+    openTypeOS2TypoDescender: int | None = None
+    openTypeOS2TypoLineGap: int | None = None
+    openTypeOS2WinAscent: int | None = field(default=None, validator=_optional_positive)
+    openTypeOS2WinDescent: int | None = field(
         default=None, validator=_optional_positive
     )
-    openTypeOS2WinDescent: Optional[int] = field(
-        default=None, validator=_optional_positive
-    )
-    openTypeOS2Type: Optional[List[int]] = None
-    openTypeOS2SubscriptXSize: Optional[int] = None
-    openTypeOS2SubscriptYSize: Optional[int] = None
-    openTypeOS2SubscriptXOffset: Optional[int] = None
-    openTypeOS2SubscriptYOffset: Optional[int] = None
-    openTypeOS2SuperscriptXSize: Optional[int] = None
-    openTypeOS2SuperscriptYSize: Optional[int] = None
-    openTypeOS2SuperscriptXOffset: Optional[int] = None
-    openTypeOS2SuperscriptYOffset: Optional[int] = None
-    openTypeOS2StrikeoutSize: Optional[int] = None
-    openTypeOS2StrikeoutPosition: Optional[int] = None
+    openTypeOS2Type: list[int] | None = None
+    openTypeOS2SubscriptXSize: int | None = None
+    openTypeOS2SubscriptYSize: int | None = None
+    openTypeOS2SubscriptXOffset: int | None = None
+    openTypeOS2SubscriptYOffset: int | None = None
+    openTypeOS2SuperscriptXSize: int | None = None
+    openTypeOS2SuperscriptYSize: int | None = None
+    openTypeOS2SuperscriptXOffset: int | None = None
+    openTypeOS2SuperscriptYOffset: int | None = None
+    openTypeOS2StrikeoutSize: int | None = None
+    openTypeOS2StrikeoutPosition: int | None = None
 
-    openTypeVheaVertTypoAscender: Optional[int] = None
-    openTypeVheaVertTypoDescender: Optional[int] = None
-    openTypeVheaVertTypoLineGap: Optional[int] = None
-    openTypeVheaCaretSlopeRise: Optional[int] = None
-    openTypeVheaCaretSlopeRun: Optional[int] = None
-    openTypeVheaCaretOffset: Optional[int] = None
+    openTypeVheaVertTypoAscender: int | None = None
+    openTypeVheaVertTypoDescender: int | None = None
+    openTypeVheaVertTypoLineGap: int | None = None
+    openTypeVheaCaretSlopeRise: int | None = None
+    openTypeVheaCaretSlopeRun: int | None = None
+    openTypeVheaCaretOffset: int | None = None
 
-    postscriptFontName: Optional[str] = None
-    postscriptFullName: Optional[str] = None
-    postscriptSlantAngle: Optional[float] = None
-    postscriptUniqueID: Optional[int] = None
-    postscriptUnderlineThickness: Optional[float] = None
-    postscriptUnderlinePosition: Optional[float] = None
-    postscriptIsFixedPitch: Optional[bool] = None
-    postscriptBlueValues: Optional[List[float]] = None
-    postscriptOtherBlues: Optional[List[float]] = None
-    postscriptFamilyBlues: Optional[List[float]] = None
-    postscriptFamilyOtherBlues: Optional[List[float]] = None
-    postscriptStemSnapH: Optional[List[float]] = None
-    postscriptStemSnapV: Optional[List[float]] = None
-    postscriptBlueFuzz: Optional[float] = None
-    postscriptBlueShift: Optional[float] = None
-    postscriptBlueScale: Optional[float] = None
-    postscriptForceBold: Optional[bool] = None
-    postscriptDefaultWidthX: Optional[float] = None
-    postscriptNominalWidthX: Optional[float] = None
-    postscriptWeightName: Optional[str] = None
-    postscriptDefaultCharacter: Optional[str] = None
-    postscriptWindowsCharacterSet: Optional[int] = None
+    postscriptFontName: str | None = None
+    postscriptFullName: str | None = None
+    postscriptSlantAngle: float | None = None
+    postscriptUniqueID: int | None = None
+    postscriptUnderlineThickness: float | None = None
+    postscriptUnderlinePosition: float | None = None
+    postscriptIsFixedPitch: bool | None = None
+    postscriptBlueValues: list[float] | None = None
+    postscriptOtherBlues: list[float] | None = None
+    postscriptFamilyBlues: list[float] | None = None
+    postscriptFamilyOtherBlues: list[float] | None = None
+    postscriptStemSnapH: list[float] | None = None
+    postscriptStemSnapV: list[float] | None = None
+    postscriptBlueFuzz: float | None = None
+    postscriptBlueShift: float | None = None
+    postscriptBlueScale: float | None = None
+    postscriptForceBold: bool | None = None
+    postscriptDefaultWidthX: float | None = None
+    postscriptNominalWidthX: float | None = None
+    postscriptWeightName: str | None = None
+    postscriptDefaultCharacter: str | None = None
+    postscriptWindowsCharacterSet: int | None = None
 
     # old stuff
-    macintoshFONDName: Optional[str] = None
-    macintoshFONDFamilyID: Optional[int] = None
-    year: Optional[int] = None
+    macintoshFONDName: str | None = None
+    macintoshFONDFamilyID: int | None = None
+    year: int | None = None
 
     # woff metadata
-    woffMajorVersion: Optional[int] = field(default=None, validator=_optional_positive)
-    woffMinorVersion: Optional[int] = field(default=None, validator=_optional_positive)
-    _woffMetadataUniqueID: Optional[WoffMetadataUniqueID] = field(
+    woffMajorVersion: int | None = field(default=None, validator=_optional_positive)
+    woffMinorVersion: int | None = field(default=None, validator=_optional_positive)
+    _woffMetadataUniqueID: WoffMetadataUniqueID | None = field(
         default=None,
         # mute mypy error "unsupported converter, only named functions and types ..."
         # The woff metadata attributes are too many to bother defining named
@@ -358,49 +357,49 @@ class Info:
     )
     woffMetadataUniqueID = _dict_setter_property(WoffMetadataUniqueID)
 
-    _woffMetadataVendor: Optional[WoffMetadataVendor] = field(
+    _woffMetadataVendor: WoffMetadataVendor | None = field(
         default=None,
         converter=WoffMetadataVendor.coerce_from_optional_dict,  # type: ignore
     )
     woffMetadataVendor = _dict_setter_property(WoffMetadataVendor)
 
-    _woffMetadataCredits: Optional[WoffMetadataCredits] = field(
+    _woffMetadataCredits: WoffMetadataCredits | None = field(
         default=None,
         converter=WoffMetadataCredits.coerce_from_optional_dict,  # type: ignore
     )
     woffMetadataCredits = _dict_setter_property(WoffMetadataCredits)
 
-    _woffMetadataDescription: Optional[WoffMetadataDescription] = field(
+    _woffMetadataDescription: WoffMetadataDescription | None = field(
         default=None,
         converter=WoffMetadataDescription.coerce_from_optional_dict,  # type: ignore
     )
     woffMetadataDescription = _dict_setter_property(WoffMetadataDescription)
 
-    _woffMetadataLicense: Optional[WoffMetadataLicense] = field(
+    _woffMetadataLicense: WoffMetadataLicense | None = field(
         default=None,
         converter=WoffMetadataLicense.coerce_from_optional_dict,  # type: ignore
     )
     woffMetadataLicense = _dict_setter_property(WoffMetadataLicense)
 
-    _woffMetadataCopyright: Optional[WoffMetadataCopyright] = field(
+    _woffMetadataCopyright: WoffMetadataCopyright | None = field(
         default=None,
         converter=WoffMetadataCopyright.coerce_from_optional_dict,  # type: ignore
     )
     woffMetadataCopyright = _dict_setter_property(WoffMetadataCopyright)
 
-    _woffMetadataTrademark: Optional[WoffMetadataTrademark] = field(
+    _woffMetadataTrademark: WoffMetadataTrademark | None = field(
         default=None,
         converter=WoffMetadataTrademark.coerce_from_optional_dict,  # type: ignore
     )
     woffMetadataTrademark = _dict_setter_property(WoffMetadataTrademark)
 
-    _woffMetadataLicensee: Optional[WoffMetadataLicensee] = field(
+    _woffMetadataLicensee: WoffMetadataLicensee | None = field(
         default=None,
         converter=WoffMetadataLicensee.coerce_from_optional_dict,  # type: ignore
     )
     woffMetadataLicensee = _dict_setter_property(WoffMetadataLicensee)
 
-    _woffMetadataExtensions: Optional[List[WoffMetadataExtension]] = field(
+    _woffMetadataExtensions: list[WoffMetadataExtension] | None = field(
         default=None,
         converter=_convert_WoffMetadataExtensions,
     )

--- a/src/ufoLib2/objects/info/woff.py
+++ b/src/ufoLib2/objects/info/woff.py
@@ -5,7 +5,8 @@ https://unifiedfontobject.org/versions/ufo3/fontinfo.plist/#woff-data
 
 from __future__ import annotations
 
-from typing import Any, List, Mapping, Optional, Sequence, Type, TypeVar
+from collections.abc import Mapping, Sequence
+from typing import Any, TypeVar
 
 from attrs import Attribute, define, field
 
@@ -15,7 +16,7 @@ _T = TypeVar("_T", bound=AttrDictMixin)
 
 
 def _convert_list_of_woff_metadata(
-    cls: Type[_T], values: Sequence[_T | Mapping[str, Any]]
+    cls: type[_T], values: Sequence[_T | Mapping[str, Any]]
 ) -> list[_T]:
     return [cls.coerce_from_dict(v) for v in values]
 
@@ -28,19 +29,19 @@ class WoffMetadataUniqueID(AttrDictMixin):
 @define
 class WoffMetadataVendor(AttrDictMixin):
     name: str
-    url: Optional[str] = None
-    dir: Optional[str] = None
+    url: str | None = None
+    dir: str | None = None
     # 'class' of course is reserved in Python
-    class_: Optional[str] = field(default=None, metadata={"rename_attr": "class"})
+    class_: str | None = field(default=None, metadata={"rename_attr": "class"})
 
 
 @define
 class WoffMetadataCredit(AttrDictMixin):
     name: str
-    url: Optional[str] = None
-    role: Optional[str] = None
-    dir: Optional[str] = None
-    class_: Optional[str] = field(default=None, metadata={"rename_attr": "class"})
+    url: str | None = None
+    role: str | None = None
+    dir: str | None = None
+    class_: str | None = field(default=None, metadata={"rename_attr": "class"})
 
 
 def _convert_list_of_woff_metadata_credits(
@@ -51,7 +52,7 @@ def _convert_list_of_woff_metadata_credits(
 
 @define
 class WoffMetadataCredits(AttrDictMixin):
-    credits: List[WoffMetadataCredit] = field(
+    credits: list[WoffMetadataCredit] = field(
         factory=list,
         converter=_convert_list_of_woff_metadata_credits,
     )
@@ -60,9 +61,9 @@ class WoffMetadataCredits(AttrDictMixin):
 @define
 class WoffMetadataText(AttrDictMixin):
     text: str
-    language: Optional[str] = None
-    dir: Optional[str] = None
-    class_: Optional[str] = field(default=None, metadata={"rename_attr": "class"})
+    language: str | None = None
+    dir: str | None = None
+    class_: str | None = field(default=None, metadata={"rename_attr": "class"})
 
 
 def _at_least_one_item(
@@ -82,8 +83,8 @@ def _convert_list_of_woff_metadata_texts(
 
 @define
 class WoffMetadataDescription(AttrDictMixin):
-    url: Optional[str] = None
-    text: List[WoffMetadataText] = field(
+    url: str | None = None
+    text: list[WoffMetadataText] = field(
         factory=list,
         validator=_at_least_one_item,
         converter=_convert_list_of_woff_metadata_texts,
@@ -92,9 +93,9 @@ class WoffMetadataDescription(AttrDictMixin):
 
 @define
 class WoffMetadataLicense(AttrDictMixin):
-    url: Optional[str] = None
-    id: Optional[str] = None
-    text: List[WoffMetadataText] = field(
+    url: str | None = None
+    id: str | None = None
+    text: list[WoffMetadataText] = field(
         factory=list,
         converter=_convert_list_of_woff_metadata_texts,
     )
@@ -102,7 +103,7 @@ class WoffMetadataLicense(AttrDictMixin):
 
 @define
 class WoffMetadataCopyright(AttrDictMixin):
-    text: List[WoffMetadataText] = field(
+    text: list[WoffMetadataText] = field(
         factory=list,
         validator=_at_least_one_item,
         converter=_convert_list_of_woff_metadata_texts,
@@ -111,7 +112,7 @@ class WoffMetadataCopyright(AttrDictMixin):
 
 @define
 class WoffMetadataTrademark(AttrDictMixin):
-    text: List[WoffMetadataText] = field(
+    text: list[WoffMetadataText] = field(
         factory=list,
         validator=_at_least_one_item,
         converter=_convert_list_of_woff_metadata_texts,
@@ -121,24 +122,24 @@ class WoffMetadataTrademark(AttrDictMixin):
 @define
 class WoffMetadataLicensee(AttrDictMixin):
     name: str
-    dir: Optional[str] = None
-    class_: Optional[str] = field(default=None, metadata={"rename_attr": "class"})
+    dir: str | None = None
+    class_: str | None = field(default=None, metadata={"rename_attr": "class"})
 
 
 @define
 class WoffMetadataExtensionName(AttrDictMixin):
     text: str
-    language: Optional[str] = None
-    dir: Optional[str] = None
-    class_: Optional[str] = field(default=None, metadata={"rename_attr": "class"})
+    language: str | None = None
+    dir: str | None = None
+    class_: str | None = field(default=None, metadata={"rename_attr": "class"})
 
 
 @define
 class WoffMetadataExtensionValue(AttrDictMixin):
     text: str
-    language: Optional[str] = None
-    dir: Optional[str] = None
-    class_: Optional[str] = field(default=None, metadata={"rename_attr": "class"})
+    language: str | None = None
+    dir: str | None = None
+    class_: str | None = field(default=None, metadata={"rename_attr": "class"})
 
 
 def _convert_list_of_woff_metadata_extension_name(
@@ -155,14 +156,14 @@ def _convert_list_of_woff_metadata_extension_value(
 
 @define
 class WoffMetadataExtensionItem(AttrDictMixin):
-    id: Optional[str] = None
-    names: List[WoffMetadataExtensionName] = field(
+    id: str | None = None
+    names: list[WoffMetadataExtensionName] = field(
         factory=list,
         validator=_at_least_one_item,
         converter=_convert_list_of_woff_metadata_extension_name,
     )
     # 'values()' is the name of the dict method, hence the attribute named 'values_'
-    values_: List[WoffMetadataExtensionValue] = field(
+    values_: list[WoffMetadataExtensionValue] = field(
         factory=list,
         validator=_at_least_one_item,
         converter=_convert_list_of_woff_metadata_extension_value,
@@ -178,13 +179,13 @@ def _convert_list_of_woff_metadata_extension_item(
 
 @define
 class WoffMetadataExtension(AttrDictMixin):
-    id: Optional[str]
-    names: List[WoffMetadataExtensionName] = field(
+    id: str | None
+    names: list[WoffMetadataExtensionName] = field(
         factory=list,
         converter=_convert_list_of_woff_metadata_extension_name,
     )
     # 'items()' is the name of the dict method, hence the attribute named 'items_'
-    items_: List[WoffMetadataExtensionItem] = field(
+    items_: list[WoffMetadataExtensionItem] = field(
         factory=list,
         validator=_at_least_one_item,
         converter=_convert_list_of_woff_metadata_extension_item,

--- a/src/ufoLib2/objects/kerning.py
+++ b/src/ufoLib2/objects/kerning.py
@@ -21,7 +21,7 @@ class Kerning(dict[KerningPair, float]):
         return result
 
     @classmethod
-    def from_nested_dicts(self, kerning: Mapping[str, Mapping[str, float]]) -> Kerning:
+    def from_nested_dicts(cls, kerning: Mapping[str, Mapping[str, float]]) -> Kerning:
         return Kerning(
             ((left, right), kerning[left][right])
             for left in kerning

--- a/src/ufoLib2/objects/kerning.py
+++ b/src/ufoLib2/objects/kerning.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, Mapping, Tuple
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
 
 from ufoLib2.serde import serde
 
 if TYPE_CHECKING:
-    from typing import Type
 
     from cattrs import Converter
 
-KerningPair = Tuple[str, str]
+KerningPair = tuple[str, str]
 
 
 @serde
-class Kerning(Dict[KerningPair, float]):
+class Kerning(dict[KerningPair, float]):
     def as_nested_dicts(self) -> dict[str, dict[str, float]]:
         result: dict[str, dict[str, float]] = {}
         for (left, right), value in self.items():
@@ -35,7 +35,7 @@ class Kerning(Dict[KerningPair, float]):
     @staticmethod
     def _structure(
         data: Mapping[str, Mapping[str, float]],
-        cls: Type[Kerning],
+        cls: type[Kerning],
         converter: Converter,
     ) -> Kerning:
         del converter  # unused

--- a/src/ufoLib2/objects/layer.py
+++ b/src/ufoLib2/objects/layer.py
@@ -40,12 +40,12 @@ _GLYPH_NOT_LOADED = Glyph(name="___UFOLIB2_LAZY_GLYPH___")
 def _convert_glyphs(value: dict[str, Glyph] | Sequence[Glyph]) -> dict[str, Glyph]:
     result: dict[str, Glyph] = {}
     if isinstance(value, dict):
-        glyph_ids = set()
+        glyph_ids: set[int] = set()
         for name, glyph in value.items():
             if not isinstance(glyph, Glyph):
                 raise TypeError(f"Expected Glyph, found {type(glyph).__name__}")
             if glyph is not _GLYPH_NOT_LOADED:
-                glyph_id = id(glyph)
+                glyph_id: int = id(glyph)
                 if glyph_id in glyph_ids:
                     raise KeyError(f"{glyph!r} can't be added twice")
                 glyph_ids.add(glyph_id)
@@ -109,7 +109,9 @@ class Layer:
     """
 
     _name: str = field(default=DEFAULT_LAYER_NAME, metadata={"omit_if_default": False})
-    _glyphs: dict[str, Glyph] = field(factory=dict, converter=_convert_glyphs)
+    _glyphs: dict[str, Glyph] = field(
+        factory=dict[str, Glyph], converter=_convert_glyphs
+    )
     color: str | None = None
     """The color assigned to the layer."""
 
@@ -432,7 +434,7 @@ class Layer:
 def _fetch_glyph_identifiers(glyph: Glyph) -> set[str]:
     """Returns all identifiers in use in a glyph."""
 
-    identifiers = set()
+    identifiers: set[str] = set()
     for anchor in glyph.anchors:
         if anchor.identifier is not None:
             identifiers.add(anchor.identifier)

--- a/src/ufoLib2/objects/layer.py
+++ b/src/ufoLib2/objects/layer.py
@@ -1,14 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Iterator, KeysView, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
-    Iterator,
-    KeysView,
-    Optional,
-    Sequence,
-    Type,
     overload,
 )
 
@@ -114,8 +109,8 @@ class Layer:
     """
 
     _name: str = field(default=DEFAULT_LAYER_NAME, metadata={"omit_if_default": False})
-    _glyphs: Dict[str, Glyph] = field(factory=dict, converter=_convert_glyphs)
-    color: Optional[str] = None
+    _glyphs: dict[str, Glyph] = field(factory=dict, converter=_convert_glyphs)
+    color: str | None = None
     """The color assigned to the layer."""
 
     _lib: Lib = field(factory=Lib, converter=_convert_Lib)
@@ -129,7 +124,7 @@ class Layer:
     _tempLib: Lib = field(factory=Lib, converter=_convert_Lib)
     """A temporary map of arbitrary plist values."""
 
-    _lazy: Optional[bool] = field(default=None, init=False, eq=False)
+    _lazy: bool | None = field(default=None, init=False, eq=False)
     _glyphSet: Any = field(default=None, init=False, eq=False)
 
     def __attrs_post_init__(self) -> None:
@@ -419,7 +414,7 @@ class Layer:
 
     @staticmethod
     def _structure(
-        data: dict[str, Any], cls: Type[Layer], converter: Converter
+        data: dict[str, Any], cls: type[Layer], converter: Converter
     ) -> Layer:
         return cls(
             name=data.get("name", DEFAULT_LAYER_NAME),

--- a/src/ufoLib2/objects/layer.py
+++ b/src/ufoLib2/objects/layer.py
@@ -4,6 +4,7 @@ from collections.abc import Iterator, KeysView, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
+    NamedTuple,
     overload,
 )
 
@@ -35,6 +36,12 @@ if TYPE_CHECKING:
     from cattrs import Converter
 
 _GLYPH_NOT_LOADED = Glyph(name="___UFOLIB2_LAZY_GLYPH___")
+
+
+class TupleUnstructured(NamedTuple):
+    key: str
+    value: bool | Lib | dict[str, dict[str, Any]]
+    default: bool | dict[Any, Any]
 
 
 def _convert_glyphs(value: dict[str, Glyph] | Sequence[Glyph]) -> dict[str, Glyph]:
@@ -401,12 +408,13 @@ class Layer:
             # the layer's "key" in the layerSet.
             "name": self._name,
         }
-        default: Any
         for key, value, default in [
-            ("default", self._default, self._name == DEFAULT_LAYER_NAME),
-            ("glyphs", glyphs, {}),
-            ("lib", self._lib, {}),
-            ("tempLib", self._tempLib, {}),
+            TupleUnstructured(
+                "default", self._default, self._name == DEFAULT_LAYER_NAME
+            ),
+            TupleUnstructured("glyphs", glyphs, {}),
+            TupleUnstructured("lib", self._lib, {}),
+            TupleUnstructured("tempLib", self._tempLib, {}),
         ]:
             if not converter.omit_if_default or value != default:
                 d[key] = value

--- a/src/ufoLib2/objects/layer.py
+++ b/src/ufoLib2/objects/layer.py
@@ -1,12 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, KeysView, Sequence
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    NamedTuple,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, NamedTuple, overload
 
 from attrs import define, field
 from fontTools.ufoLib.glifLib import GlyphSet

--- a/src/ufoLib2/objects/layerSet.py
+++ b/src/ufoLib2/objects/layerSet.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Iterable, Iterator, Sized
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
     Any,
-    Dict,
-    Iterable,
-    Iterator,
-    Optional,
-    Sized,
 )
 
 from attrs import define, field
@@ -26,7 +22,6 @@ from ufoLib2.serde import serde
 from ufoLib2.typing import T
 
 if TYPE_CHECKING:
-    from typing import Type
 
     from cattrs import Converter
 
@@ -74,14 +69,14 @@ class LayerSet:
             del font.layers["myLayerName"]
     """
 
-    _layers: Dict[str, Layer] = field(
+    _layers: dict[str, Layer] = field(
         validator=_must_have_at_least_one_item,
     )
 
     _defaultLayer: Layer = field(default=_LAYER_NOT_LOADED, eq=False)
 
-    _lazy: Optional[bool] = field(default=None, init=False, eq=False)
-    _reader: Optional[UFOReader] = field(default=None, init=False, eq=False)
+    _lazy: bool | None = field(default=None, init=False, eq=False)
+    _reader: UFOReader | None = field(default=None, init=False, eq=False)
 
     def __attrs_post_init__(self) -> None:
         if self._defaultLayer == _LAYER_NOT_LOADED:
@@ -392,6 +387,6 @@ class LayerSet:
 
     @staticmethod
     def _structure(
-        data: list[dict[str, Any]], cls: Type[LayerSet], converter: Converter
+        data: list[dict[str, Any]], cls: type[LayerSet], converter: Converter
     ) -> LayerSet:
         return cls.from_iterable(converter.structure(layer, Layer) for layer in data)

--- a/src/ufoLib2/objects/layerSet.py
+++ b/src/ufoLib2/objects/layerSet.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Iterator, Sized
-from typing import (
-    TYPE_CHECKING,
-    AbstractSet,
-    Any,
-)
+from typing import TYPE_CHECKING, AbstractSet, Any
 
 from attrs import define, field
 from fontTools.ufoLib import UFOReader, UFOWriter

--- a/src/ufoLib2/objects/lib.py
+++ b/src/ufoLib2/objects/lib.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, overload
 
 from ufoLib2.constants import DATA_LIB_KEY
 from ufoLib2.serde import serde
+from ufoLib2.typing import K, T
 
 if TYPE_CHECKING:
 
@@ -53,7 +54,22 @@ def is_data_dict(value: Any) -> bool:
     )
 
 
-def _unstructure_data(value: Any, converter: Converter) -> Any:
+@overload
+def _unstructure_data(value: bytes, converter: Converter) -> dict[str, str | Any]: ...
+@overload
+def _unstructure_data(value: list[Any], converter: Converter) -> list[Any]: ...
+@overload
+def _unstructure_data(value: tuple[Any, ...], converter: Converter) -> list[Any]: ...
+@overload
+def _unstructure_data(value: Mapping[K, Any], converter: Converter) -> dict[K, Any]: ...
+@overload
+def _unstructure_data(value: T, converter: Converter) -> T: ...
+
+
+def _unstructure_data(
+    value: bytes | list[Any] | tuple[Any, ...] | Mapping[K, Any] | T,
+    converter: Converter,
+) -> dict[str, str | Any] | list[Any] | dict[K, Any] | T:
     if isinstance(value, bytes):
         return {"type": DATA_LIB_KEY, "data": converter.unstructure(value)}
     elif isinstance(value, (list, tuple)):

--- a/src/ufoLib2/objects/lib.py
+++ b/src/ufoLib2/objects/lib.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, Mapping, Union, cast
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, cast
 
 from ufoLib2.constants import DATA_LIB_KEY
 from ufoLib2.serde import serde
 
 if TYPE_CHECKING:
-    from typing import Type
 
     from cattrs import Converter
 
@@ -64,7 +64,7 @@ def _unstructure_data(value: Any, converter: Converter) -> Any:
 
 
 def _structure_data_inplace(
-    key: Union[int, str], value: Any, container: Any, converter: Converter
+    key: int | str, value: Any, container: Any, converter: Converter
 ) -> None:
     if isinstance(value, list):
         for i, v in enumerate(value):
@@ -77,7 +77,7 @@ def _structure_data_inplace(
 
 
 @serde
-class Lib(Dict[str, Any]):
+class Lib(dict[str, Any]):
     def _unstructure(self, converter: Converter) -> dict[str, Any]:
         # avoid encoding if converter supports bytes natively
         test = converter.unstructure(b"\0")
@@ -92,7 +92,7 @@ class Lib(Dict[str, Any]):
     @staticmethod
     def _structure(
         data: Mapping[str, Any],
-        cls: Type[Lib],
+        cls: type[Lib],
         converter: Converter,
     ) -> Lib:
         self = cls(data)

--- a/src/ufoLib2/objects/lib.py
+++ b/src/ufoLib2/objects/lib.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, cast, overload
+from datetime import datetime
+from functools import partial
+from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar, cast, overload
 
 from ufoLib2.constants import DATA_LIB_KEY
 from ufoLib2.serde import serde
-from ufoLib2.typing import K, T
 
 if TYPE_CHECKING:
 
@@ -54,28 +55,80 @@ def is_data_dict(value: Any) -> bool:
     )
 
 
+PlistScalar: TypeAlias = bool | datetime | float | int | str
+PlistContainer: TypeAlias = (
+    Mapping[str, PlistScalar] | list[PlistScalar] | tuple[PlistScalar, ...]
+)
+PlistEncodable: TypeAlias = (
+    Mapping[str, PlistContainer] | list[PlistContainer] | tuple[PlistContainer, ...]
+)
+
+形PlistScalar = TypeVar("形PlistScalar", bool, datetime, float, int, str)
+形PlistContainer = TypeVar(
+    "形PlistContainer",
+    Mapping[str, PlistScalar],
+    list[PlistScalar],
+    tuple[PlistScalar, ...],
+)
+形PlistEncodable = TypeVar(
+    "形PlistEncodable",
+    Mapping[str, PlistContainer],
+    list[PlistContainer],
+    tuple[PlistContainer, ...],
+)
+
+
 @overload
-def _unstructure_data(value: bytes, converter: Converter) -> dict[str, str | Any]: ...
+def _unstructure_data(value: bytes, converter: Converter) -> dict[str, PlistScalar]: ...
+
+
 @overload
-def _unstructure_data(value: list[Any], converter: Converter) -> list[Any]: ...
+def _unstructure_data(
+    value: list[PlistEncodable], converter: Converter
+) -> list[PlistEncodable]: ...
+
+
 @overload
-def _unstructure_data(value: tuple[Any, ...], converter: Converter) -> list[Any]: ...
+def _unstructure_data(
+    value: tuple[PlistEncodable, ...], converter: Converter
+) -> list[PlistEncodable]: ...
+
+
 @overload
-def _unstructure_data(value: Mapping[K, Any], converter: Converter) -> dict[K, Any]: ...
+def _unstructure_data(
+    value: Mapping[str, PlistEncodable], converter: Converter
+) -> dict[str, PlistEncodable]: ...
+
+
 @overload
-def _unstructure_data(value: T, converter: Converter) -> T: ...
+def _unstructure_data(value: 形PlistScalar, converter: Converter) -> 形PlistScalar: ...
 
 
 def _unstructure_data(
-    value: bytes | list[Any] | tuple[Any, ...] | Mapping[K, Any] | T,
+    value: (
+        bytes
+        | list[PlistEncodable]
+        | tuple[PlistEncodable, ...]
+        | Mapping[str, PlistEncodable]
+        | 形PlistScalar
+    ),
     converter: Converter,
-) -> dict[str, str | Any] | list[Any] | dict[K, Any] | T:
+) -> (
+    dict[str, PlistScalar]
+    | list[PlistEncodable]
+    | dict[str, PlistEncodable]
+    | 形PlistScalar
+):
+    recurse: partial[PlistEncodable] = partial(_unstructure_data, converter=converter)
     if isinstance(value, bytes):
         return {"type": DATA_LIB_KEY, "data": converter.unstructure(value)}
     elif isinstance(value, (list, tuple)):
-        return [_unstructure_data(v, converter) for v in value]
+        return list(map(recurse, value))
     elif isinstance(value, Mapping):
-        return {k: _unstructure_data(v, converter) for k, v in value.items()}
+        kk = tuple(value.keys())
+        vv = tuple(value.values())
+        rr = tuple(map(recurse, vv))
+        return dict(zip(kk, rr, strict=True))
     return value
 
 
@@ -94,15 +147,17 @@ def _structure_data_inplace(
 
 @serde
 class Lib(dict[str, Any]):
-    def _unstructure(self, converter: Converter) -> dict[str, Any]:
+    def _unstructure(
+        self, converter: Converter
+    ) -> dict[str, bytes | PlistEncodable] | dict[str, PlistEncodable]:
         # avoid encoding if converter supports bytes natively
-        test = converter.unstructure(b"\0")
+        test: bytes | str | object = converter.unstructure(b"\0")
         if isinstance(test, bytes):
             return dict(self)
         elif not isinstance(test, str):
             raise NotImplementedError(type(test))
 
-        data: dict[str, Any] = _unstructure_data(self, converter)
+        data: dict[str, PlistEncodable] = _unstructure_data(self, converter)
         return data
 
     @staticmethod

--- a/src/ufoLib2/objects/lib.py
+++ b/src/ufoLib2/objects/lib.py
@@ -1,40 +1,40 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, MutableMapping, MutableSequence
 from datetime import datetime
-from functools import partial
-from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar, cast, overload
+from typing import Any, TypeAlias, cast
+
+from cattrs import Converter
+from typing_extensions import TypeIs
 
 from ufoLib2.constants import DATA_LIB_KEY
 from ufoLib2.serde import serde
 
-if TYPE_CHECKING:
-
-    from cattrs import Converter
-
-# unfortunately mypy is not smart enough to support recursive types like plist...
-# PlistEncodable = Union[
-#     bool,
-#     bytes,
-#     datetime,
-#     float,
-#     int,
-#     str,
-#     Mapping[str, PlistEncodable],
-#     Sequence[PlistEncodable],
-# ]
+PlistEncodable: TypeAlias = (
+    bool
+    | bytes
+    | datetime
+    | float
+    | int
+    | str
+    | MutableMapping[str, "PlistEncodable"]
+    | MutableSequence["PlistEncodable"]
+)
 
 
-def _convert_Lib(value: Mapping[str, Any]) -> Lib:
+# TODO if `Lib(value)` returns a `dict` subclass, then `value` can be `Mapping`, otherwise is must be
+# `MutableMapping`.
+def _convert_Lib(value: Mapping[str, PlistEncodable]) -> Lib:
     return value if isinstance(value, Lib) else Lib(value)
 
 
 # getter/setter properties used by Font, Layer, Glyph
+# TODO can we make `self: Any` more specific?
 def _get_lib(self: Any) -> Lib:
     return cast(Lib, self._lib)
 
 
-def _set_lib(self: Any, value: Mapping[str, Any]) -> None:
+def _set_lib(self: Any, value: Mapping[str, PlistEncodable]) -> None:
     self._lib = _convert_Lib(value)
 
 
@@ -42,114 +42,57 @@ def _get_tempLib(self: Any) -> Lib:
     return cast(Lib, self._tempLib)
 
 
-def _set_tempLib(self: Any, value: Mapping[str, Any]) -> None:
+def _set_tempLib(self: Any, value: Mapping[str, PlistEncodable]) -> None:
     self._tempLib = _convert_Lib(value)
 
 
-def is_data_dict(value: Any) -> bool:
+def is_data_dict(value: PlistEncodable) -> TypeIs[MutableMapping[str, PlistEncodable]]:
     return (
-        isinstance(value, Mapping)
+        isinstance(value, MutableMapping)
         and "type" in value
         and value["type"] == DATA_LIB_KEY
         and "data" in value
     )
 
 
-PlistScalar: TypeAlias = bool | datetime | float | int | str
-PlistContainer: TypeAlias = (
-    Mapping[str, PlistScalar] | list[PlistScalar] | tuple[PlistScalar, ...]
-)
-PlistEncodable: TypeAlias = (
-    Mapping[str, PlistContainer] | list[PlistContainer] | tuple[PlistContainer, ...]
-)
-
-形PlistScalar = TypeVar("形PlistScalar", bool, datetime, float, int, str)
-形PlistContainer = TypeVar(
-    "形PlistContainer",
-    Mapping[str, PlistScalar],
-    list[PlistScalar],
-    tuple[PlistScalar, ...],
-)
-形PlistEncodable = TypeVar(
-    "形PlistEncodable",
-    Mapping[str, PlistContainer],
-    list[PlistContainer],
-    tuple[PlistContainer, ...],
-)
-
-
-@overload
-def _unstructure_data(value: bytes, converter: Converter) -> dict[str, PlistScalar]: ...
-
-
-@overload
-def _unstructure_data(
-    value: list[PlistEncodable], converter: Converter
-) -> list[PlistEncodable]: ...
-
-
-@overload
-def _unstructure_data(
-    value: tuple[PlistEncodable, ...], converter: Converter
-) -> list[PlistEncodable]: ...
-
-
-@overload
-def _unstructure_data(
-    value: Mapping[str, PlistEncodable], converter: Converter
-) -> dict[str, PlistEncodable]: ...
-
-
-@overload
-def _unstructure_data(value: 形PlistScalar, converter: Converter) -> 形PlistScalar: ...
-
-
-def _unstructure_data(
-    value: (
-        bytes
-        | list[PlistEncodable]
-        | tuple[PlistEncodable, ...]
-        | Mapping[str, PlistEncodable]
-        | 形PlistScalar
-    ),
-    converter: Converter,
-) -> (
-    dict[str, PlistScalar]
-    | list[PlistEncodable]
-    | dict[str, PlistEncodable]
-    | 形PlistScalar
-):
-    recurse: partial[PlistEncodable] = partial(_unstructure_data, converter=converter)
+def _unstructure_data(value: PlistEncodable, converter: Converter) -> PlistEncodable:
     if isinstance(value, bytes):
         return {"type": DATA_LIB_KEY, "data": converter.unstructure(value)}
-    elif isinstance(value, (list, tuple)):
-        return list(map(recurse, value))
-    elif isinstance(value, Mapping):
-        kk = tuple(value.keys())
-        vv = tuple(value.values())
-        rr = tuple(map(recurse, vv))
-        return dict(zip(kk, rr, strict=True))
+    elif isinstance(value, MutableSequence):
+        return list(_unstructure_data(v, converter) for v in value)
+    elif isinstance(value, MutableMapping):
+        return {k: _unstructure_data(v, converter) for k, v in value.items()}
     return value
 
 
+# NOTE "inplace" requires `Mutable*`.
 def _structure_data_inplace(
-    key: int | str, value: Any, container: Any, converter: Converter
+    key: int | str,
+    value: PlistEncodable,
+    container: MutableMapping[str, PlistEncodable] | MutableSequence[PlistEncodable],
+    converter: Converter,
 ) -> None:
-    if isinstance(value, list):
+    if isinstance(value, MutableSequence):
         for i, v in enumerate(value):
             _structure_data_inplace(i, v, value, converter)
-    elif is_data_dict(value):
+    # TODO I _feel_ like this shouldn't need 3 checks.
+    elif (
+        is_data_dict(value)
+        and isinstance(key, str)
+        and isinstance(container, MutableMapping)
+    ):
         container[key] = converter.structure(value["data"], bytes)
-    elif isinstance(value, Mapping):
+    elif isinstance(value, MutableMapping):
         for k, v in value.items():
             _structure_data_inplace(k, v, value, converter)
+    # TODO I _feel_ like `_structure_data_inplace` should "symmetrical" with `_unstructure_data`, but
+    # `_structure_data_inplace` does not have an analog to `return value`. That makes me wonder if the
+    # logic needs to be changed.
 
 
 @serde
-class Lib(dict[str, Any]):
-    def _unstructure(
-        self, converter: Converter
-    ) -> dict[str, bytes | PlistEncodable] | dict[str, PlistEncodable]:
+class Lib(dict[str, PlistEncodable]):
+    def _unstructure(self, converter: Converter) -> PlistEncodable:
         # avoid encoding if converter supports bytes natively
         test: bytes | str | object = converter.unstructure(b"\0")
         if isinstance(test, bytes):
@@ -157,16 +100,13 @@ class Lib(dict[str, Any]):
         elif not isinstance(test, str):
             raise NotImplementedError(type(test))
 
-        data: dict[str, PlistEncodable] = _unstructure_data(self, converter)
-        return data
+        return _unstructure_data(self, converter)
 
     @staticmethod
     def _structure(
-        data: Mapping[str, Any],
-        cls: type[Lib],
-        converter: Converter,
+        data: Mapping[str, PlistEncodable], cls: type[Lib], converter: Converter
     ) -> Lib:
-        self = cls(data)
+        self: Lib = cls(data)
         for k, v in self.items():
             _structure_data_inplace(k, v, self, converter)
         return self

--- a/src/ufoLib2/objects/misc.py
+++ b/src/ufoLib2/objects/misc.py
@@ -2,19 +2,13 @@ from __future__ import annotations
 
 import uuid
 from abc import abstractmethod
+from collections.abc import Iterator, Mapping, MutableMapping, Sequence
 from copy import deepcopy
 from functools import lru_cache
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
-    Iterator,
-    Mapping,
-    MutableMapping,
     NamedTuple,
-    Optional,
-    Sequence,
-    Set,
     Type,
     TypeVar,
     cast,
@@ -87,7 +81,7 @@ def _deepcopy_unlazify_attrs(self: Any, memo: Any) -> Any:
     )
 
 
-def _getstate_unlazify_attrs(self: Any) -> Dict[str, Any]:
+def _getstate_unlazify_attrs(self: Any) -> dict[str, Any]:
     if self._lazy:
         self.unlazify()
     return {
@@ -102,7 +96,7 @@ _obj_setattr = object.__setattr__
 # Since we override __getstate__, we must also override __setstate__.
 # Below is adapted from `attrs._make._ClassBuilder._make_getstate_setstate` method:
 # https://github.com/python-attrs/attrs/blob/36ed0204/src/attr/_make.py#L931-L937
-def _setstate_attrs(self: Any, state: Dict[str, Any]) -> None:
+def _setstate_attrs(self: Any, state: dict[str, Any]) -> None:
     _bound_setattr = _obj_setattr.__get__(self, attrs.Attribute)
     for a in attrs.fields(self.__class__):
         if a.name in state:
@@ -166,11 +160,11 @@ class DataStore(MutableMapping[str, bytes]):
     differ in which reader and writer methods they call.
     """
 
-    _data: Dict[str, bytes] = field(factory=dict)
+    _data: dict[str, bytes] = field(factory=dict)
 
-    _lazy: Optional[bool] = field(default=False, kw_only=True, eq=False, init=False)
-    _reader: Optional[UFOReader] = field(default=None, init=False, repr=False, eq=False)
-    _scheduledForDeletion: Set[str] = field(
+    _lazy: bool | None = field(default=False, kw_only=True, eq=False, init=False)
+    _reader: UFOReader | None = field(default=None, init=False, repr=False, eq=False)
+    _scheduledForDeletion: set[str] = field(
         factory=set, init=False, repr=False, eq=False
     )
 
@@ -330,7 +324,7 @@ class DataStore(MutableMapping[str, bytes]):
     @staticmethod
     def _structure(
         data: Mapping[str, Any],
-        cls: Type[DataStore],
+        cls: type[DataStore],
         converter: Converter,
     ) -> DataStore:
         self = cls()
@@ -361,7 +355,7 @@ class AttrDictMixin(Mapping[str, Any]):
     @classmethod
     @lru_cache(maxsize=None)
     def _key_to_attr_map(
-        cls: Type[AttrsInstance], reverse: bool = False
+        cls: type[AttrsInstance], reverse: bool = False
     ) -> dict[str, str]:
         result = {}
         for a in attrs.fields(cls):
@@ -396,7 +390,7 @@ class AttrDictMixin(Mapping[str, Any]):
         return sum(1 for _ in self)
 
     @classmethod
-    def coerce_from_dict(cls: Type[_T], value: _T | Mapping[str, Any]) -> _T:
+    def coerce_from_dict(cls: type[_T], value: _T | Mapping[str, Any]) -> _T:
         if isinstance(value, cls):
             return value
         elif isinstance(value, Mapping):
@@ -408,7 +402,7 @@ class AttrDictMixin(Mapping[str, Any]):
 
     @classmethod
     def coerce_from_optional_dict(
-        cls: Type[_T], value: _T | Mapping[str, Any] | None
+        cls: type[_T], value: _T | Mapping[str, Any] | None
     ) -> _T | None:
         if value is None:
             return None

--- a/src/ufoLib2/objects/misc.py
+++ b/src/ufoLib2/objects/misc.py
@@ -160,12 +160,12 @@ class DataStore(MutableMapping[str, bytes]):
     differ in which reader and writer methods they call.
     """
 
-    _data: dict[str, bytes] = field(factory=dict)
+    _data: dict[str, bytes] = field(factory=dict[str, bytes])
 
     _lazy: bool | None = field(default=False, kw_only=True, eq=False, init=False)
     _reader: UFOReader | None = field(default=None, init=False, repr=False, eq=False)
     _scheduledForDeletion: set[str] = field(
-        factory=set, init=False, repr=False, eq=False
+        factory=set[str], init=False, repr=False, eq=False
     )
 
     def __eq__(self, other: object) -> bool:
@@ -357,7 +357,7 @@ class AttrDictMixin(Mapping[str, Any]):
     def _key_to_attr_map(
         cls: type[AttrsInstance], reverse: bool = False
     ) -> dict[str, str]:
-        result = {}
+        result: dict[str, str] = {}
         for a in attrs.fields(cls):
             attr_name = a.name
             key = attr_name

--- a/src/ufoLib2/objects/misc.py
+++ b/src/ufoLib2/objects/misc.py
@@ -5,14 +5,7 @@ from abc import abstractmethod
 from collections.abc import Iterator, Mapping, MutableMapping, Sequence
 from copy import deepcopy
 from functools import lru_cache
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    NamedTuple,
-    Type,
-    TypeVar,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, NamedTuple, Type, TypeVar, cast
 
 import attrs
 from attrs import define, field

--- a/src/ufoLib2/objects/point.py
+++ b/src/ufoLib2/objects/point.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from attrs import define
 
 from ufoLib2.serde import serde
@@ -21,7 +19,7 @@ class Point:
     y: float
     """The y coordinate of the point."""
 
-    type: Optional[str] = None
+    type: str | None = None
     """The type of the point.
 
     ``None`` means "offcurve".
@@ -32,10 +30,10 @@ class Point:
     smooth: bool = False
     """Whether a smooth curvature should be maintained at this point."""
 
-    name: Optional[str] = None
+    name: str | None = None
     """The name of the point, no uniqueness required."""
 
-    identifier: Optional[str] = None
+    identifier: str | None = None
     """The globally unique identifier of the point."""
 
     # XXX: Add post_init to check spec-mandated invariants?

--- a/src/ufoLib2/serde/__init__.py
+++ b/src/ufoLib2/serde/__init__.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from functools import partialmethod
 from importlib import import_module
-from typing import IO, Any, AnyStr, Callable, Type
+from typing import IO, Any, AnyStr
 
 from ufoLib2.errors import ExtrasNotInstalledError
 from ufoLib2.typing import PathLike, T
@@ -15,13 +16,13 @@ _SERDE_FORMATS_ = ("json", "msgpack")
 # functions the input string or file-like object is the first argument and the second
 # argument is the object_class, so below just swap the order of the arguments
 def _loads(
-    cls: Type[T], s: str | bytes, *, __callback: Callable[..., T], **kwargs: Any
+    cls: type[T], s: str | bytes, *, __callback: Callable[..., T], **kwargs: Any
 ) -> T:
     return __callback(s, cls, **kwargs)
 
 
 def _load(
-    cls: Type[T],
+    cls: type[T],
     fp: PathLike | IO[AnyStr],
     *,
     __callback: Callable[..., T],
@@ -30,7 +31,7 @@ def _load(
     return __callback(fp, cls, **kwargs)
 
 
-def serde(cls: Type[T]) -> Type[T]:
+def serde(cls: type[T]) -> type[T]:
     """Decorator to add serialization support to a ufoLib2 class.
 
     This adds f"{format}_loads" / f"{format}_dumps" (from/to bytes) methods, and

--- a/src/ufoLib2/serde/json.py
+++ b/src/ufoLib2/serde/json.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any, BinaryIO, Type
+from typing import Any, BinaryIO
 
 from ufoLib2.converters import structure, unstructure
 from ufoLib2.serde.util import read_bytes, write_bytes
@@ -40,7 +40,7 @@ def dumps(
     return result
 
 
-def loads(s: str | bytes, object_class: Type[T], **kwargs: Any) -> T:
+def loads(s: str | bytes, object_class: type[T], **kwargs: Any) -> T:
     if have_orjson:
         data = orjson.loads(s, **kwargs)
     else:
@@ -58,5 +58,5 @@ def dump(
     write_bytes(fp, dumps(obj, indent=indent, sort_keys=sort_keys, **kwargs))
 
 
-def load(fp: PathLike | BinaryIO, object_class: Type[T], **kwargs: Any) -> T:
+def load(fp: PathLike | BinaryIO, object_class: type[T], **kwargs: Any) -> T:
     return loads(read_bytes(fp), object_class, **kwargs)

--- a/src/ufoLib2/serde/msgpack.py
+++ b/src/ufoLib2/serde/msgpack.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, BinaryIO, Type, cast
+from typing import Any, BinaryIO, cast
 
 import msgpack  # type: ignore
 
@@ -15,7 +15,7 @@ def dumps(obj: Any, **kwargs: Any) -> bytes:
     return cast(bytes, result)
 
 
-def loads(s: bytes, object_class: Type[T], **kwargs: Any) -> T:
+def loads(s: bytes, object_class: type[T], **kwargs: Any) -> T:
     data = msgpack.unpackb(s, **kwargs)
     return binary_converter.structure(data, object_class)
 
@@ -24,5 +24,5 @@ def dump(obj: Any, fp: PathLike | BinaryIO, **kwargs: Any) -> None:
     write_bytes(fp, dumps(obj, **kwargs))
 
 
-def load(fp: PathLike | BinaryIO, object_class: Type[T], **kwargs: Any) -> T:
+def load(fp: PathLike | BinaryIO, object_class: type[T], **kwargs: Any) -> T:
     return loads(read_bytes(fp), object_class, **kwargs)

--- a/src/ufoLib2/typing.py
+++ b/src/ufoLib2/typing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Hashable
 from typing import Protocol, TypeVar, Union
 
 from fontTools.pens.basePen import AbstractPen
@@ -8,6 +9,9 @@ from fontTools.pens.pointPen import AbstractPointPen
 
 T = TypeVar("T")
 """Generic variable for mypy for trivial generic function signatures."""
+
+K = TypeVar("K", bound=Hashable)
+"""Generic variable for mypy for mapping keys."""
 
 PathLike = Union[str, bytes, "os.PathLike[str]", "os.PathLike[bytes]"]
 """Represents a path in various possible forms."""

--- a/tests/objects/test_font.py
+++ b/tests/objects/test_font.py
@@ -123,7 +123,7 @@ def test_pickle_lazy_font(datadir: Path, lazy: bool | None) -> None:
 
     assert isinstance(data, bytes) and len(data) > 0
 
-    # picklying unlazifies
+    # pickling unlazifies
     if lazy:
         assert font._lazy is False
     else:

--- a/tests/objects/test_font.py
+++ b/tests/objects/test_font.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pickle
 from pathlib import Path
-from typing import Optional
 
 import pytest
 
@@ -110,7 +109,7 @@ def test_data_images_init() -> None:
 @pytest.mark.parametrize(
     "lazy", [None, False, True], ids=["lazy-unset", "non-lazy", "lazy"]
 )
-def test_pickle_lazy_font(datadir: Path, lazy: Optional[bool]) -> None:
+def test_pickle_lazy_font(datadir: Path, lazy: bool | None) -> None:
     if lazy is not None:
         font = Font.open(datadir / "UbuTestData.ufo", lazy=lazy)
     else:

--- a/tests/serde/test_json.py
+++ b/tests/serde/test_json.py
@@ -7,11 +7,10 @@ from typing import Any
 import pytest
 
 import ufoLib2.objects
+import ufoLib2.serde.json  # noqa: E402
 
 # isort: off
 pytest.importorskip("cattrs")
-
-import ufoLib2.serde.json  # noqa: E402
 
 
 @pytest.mark.parametrize("have_orjson", [False, True], ids=["no-orjson", "with-orjson"])

--- a/tests/serde/test_json.py
+++ b/tests/serde/test_json.py
@@ -7,10 +7,11 @@ from typing import Any
 import pytest
 
 import ufoLib2.objects
-import ufoLib2.serde.json  # noqa: E402
 
 # isort: off
 pytest.importorskip("cattrs")
+
+import ufoLib2.serde.json  # noqa: E402
 
 
 @pytest.mark.parametrize("have_orjson", [False, True], ids=["no-orjson", "with-orjson"])

--- a/tests/serde/test_json.py
+++ b/tests/serde/test_json.py
@@ -95,7 +95,7 @@ def test_not_allow_bytes(ufo_UbuTestData: ufoLib2.objects.Font) -> None:
     assert all(isinstance(v, bytes) for v in font.data.values())
 
     # bytes are are not allowed in JSON, so our converter automatically
-    # translates them to Base64 strings upon serializig
+    # translates them to Base64 strings upon serializing
     s = font.data.json_dumps()  # type: ignore
 
     # check that (before structuring the DataSet object) the json data

--- a/tests/serde/test_msgpack.py
+++ b/tests/serde/test_msgpack.py
@@ -1,14 +1,16 @@
 from pathlib import Path
 
-import msgpack  # type: ignore  # noqa
 import pytest
 
 import ufoLib2.objects
-import ufoLib2.serde.msgpack  # noqa: E402
 
 # isort: off
 pytest.importorskip("cattrs")
 pytest.importorskip("msgpack")
+
+import msgpack  # type: ignore  # noqa
+
+import ufoLib2.serde.msgpack  # noqa: E402
 
 
 def test_dumps_loads(ufo_UbuTestData: ufoLib2.objects.Font) -> None:

--- a/tests/serde/test_msgpack.py
+++ b/tests/serde/test_msgpack.py
@@ -32,7 +32,7 @@ def test_dump_load(tmp_path: Path, ufo_UbuTestData: ufoLib2.objects.Font) -> Non
 
     assert font == font2
 
-    # laod/dump work with paths too, not just file objects
+    # load/dump work with paths too, not just file objects
     font3 = ufoLib2.objects.Font.msgpack_load(tmp_path / "test.msgpack")  # type: ignore
 
     assert font == font3
@@ -51,7 +51,7 @@ def test_allow_bytes(ufo_UbuTestData: ufoLib2.objects.Font) -> None:
     assert all(isinstance(v, bytes) for v in font.data.values())
 
     # bytes *are* allowed in MessagePack (unlike JSON), so its converter should
-    # keep them as such (not translate them to Base64 str) upon serializig
+    # keep them as such (not translate them to Base64 str) upon serializing
     b = font.data.msgpack_dumps()  # type: ignore
 
     # check that (even before structuring the DataSet object) the msgpack raw data

--- a/tests/serde/test_msgpack.py
+++ b/tests/serde/test_msgpack.py
@@ -1,16 +1,14 @@
 from pathlib import Path
 
+import msgpack  # type: ignore  # noqa
 import pytest
 
 import ufoLib2.objects
+import ufoLib2.serde.msgpack  # noqa: E402
 
 # isort: off
 pytest.importorskip("cattrs")
 pytest.importorskip("msgpack")
-
-import msgpack  # type: ignore  # noqa
-
-import ufoLib2.serde.msgpack  # noqa: E402
 
 
 def test_dumps_loads(ufo_UbuTestData: ufoLib2.objects.Font) -> None:

--- a/tests/serde/test_serde.py
+++ b/tests/serde/test_serde.py
@@ -1,5 +1,5 @@
 import importlib
-from typing import Any, Dict, List
+from typing import Any
 
 import pytest
 from attrs import define
@@ -65,7 +65,7 @@ def test_msgpack_not_installed() -> None:
     assert_extras_not_installed("msgpack", "msgpack")
 
 
-BASIC_EMPTY_OBJECTS: List[Dict[str, Any]] = [
+BASIC_EMPTY_OBJECTS: list[dict[str, Any]] = [
     {"class_name": "Anchor", "args": (0, 0)},
     {"class_name": "Component", "args": ("a",)},
     {"class_name": "Contour", "args": ()},
@@ -95,7 +95,7 @@ assert {d["class_name"] for d in BASIC_EMPTY_OBJECTS} == set(ufoLib2.objects.__a
     BASIC_EMPTY_OBJECTS,
     ids=lambda x: x["class_name"],
 )
-def test_serde_all_objects(fmt: str, object_info: Dict[str, Any]) -> None:
+def test_serde_all_objects(fmt: str, object_info: dict[str, Any]) -> None:
     for req in EXTRAS_REQUIREMENTS[fmt]:
         pytest.importorskip(req)
 

--- a/tests/test_ufoLib2.py
+++ b/tests/test_ufoLib2.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import zipfile
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Type
+from typing import Any
 
 import pytest
 from fontTools import ufoLib
@@ -278,7 +278,7 @@ def test_features_normalize_newlines() -> None:
     ],
 )
 def test_convert_on_setattr(
-    klass: Type[Any], attr_name: str, attr_type: Type[Any], obj: Any
+    klass: type[Any], attr_name: str, attr_type: type[Any], obj: Any
 ) -> None:
     o = klass()
     assert isinstance(getattr(o, attr_name), attr_type)


### PR DESCRIPTION
Update type hints to use `type` instead of `Type`, remove unnecessary checks, and fix typos throughout the codebase. Enhance type annotations for better clarity and maintainability. A continuation of #423.